### PR TITLE
Fix edit view input persistence

### DIFF
--- a/.changeset/fix-edit-view-inputs.md
+++ b/.changeset/fix-edit-view-inputs.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Fix edit view text input so typing, deleting, and pasting in translation fields persists correctly.

--- a/src/utilities/editor/editorView.ts
+++ b/src/utilities/editor/editorView.ts
@@ -18,6 +18,7 @@ import { saveProject } from "../../main.js"
 export interface UpdateBundleMessage {
 	command: string
 	change: ChangeEventDetail
+	persist?: boolean
 }
 
 /**
@@ -39,6 +40,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 	let panel: WebviewPanel | undefined
 	let disposables: Disposable[] = []
 	let bundleId = initialBundleId
+	let pendingUpdate = Promise.resolve()
 
 	/**
 	 * Opens a new panel if none is open, otherwise reveals the existing one.
@@ -64,6 +66,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		// Set up disposal
 		panel.onDidDispose(
 			() => {
+				void persistEdit()
 				dispose()
 				panel = undefined
 			},
@@ -119,7 +122,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						message: message.message,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "delete-variant":
 					await deleteVariant({
@@ -127,7 +130,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						variantId: message.id,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "delete-bundle":
 					await deleteBundleNested({
@@ -135,15 +138,17 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						bundleId: message.id,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "change":
-					await handleUpdateBundle({
-						db: state().project?.db,
-						message,
-					})
+					await queueUpdate(message)
 
-					updateView()
+					if (message.persist === true) {
+						await updateView()
+					}
+					return
+				case "persist-edit":
+					await persistEdit()
 					return
 				case "show-info-message":
 					msg(message.message, "info", "statusBar", vscode.StatusBarAlignment.Right, 3000)
@@ -159,10 +164,22 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		disposables.push(disposable)
 	}
 
+	function queueUpdate(message: UpdateBundleMessage) {
+		pendingUpdate = pendingUpdate.then(() =>
+			handleUpdateBundle({
+				db: state().project?.db,
+				message,
+			})
+		)
+		return pendingUpdate
+	}
+
 	/**
 	 * Update view
 	 */
 	async function updateView() {
+		await pendingUpdate
+
 		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 		CONFIGURATION.EVENTS.ON_DID_EDITOR_VIEW_CHANGE.fire()
 
@@ -173,6 +190,22 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 				settings: await state().project?.settings.get(),
 			},
 		})
+
+		const workspaceFolder = vscode.workspace.workspaceFolders![0]
+		if (workspaceFolder) {
+			try {
+				await saveProject()
+			} catch (error) {
+				console.error("Failed to save project", error)
+				msg(`Failed to save project. ${String(error)}`, "error")
+			}
+		}
+	}
+
+	async function persistEdit() {
+		await pendingUpdate
+
+		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 
 		const workspaceFolder = vscode.workspace.workspaceFolders![0]
 		if (workspaceFolder) {

--- a/src/utilities/editor/helper/handleBundleUpdate.ts
+++ b/src/utilities/editor/helper/handleBundleUpdate.ts
@@ -1,7 +1,5 @@
 import type { InlangDatabaseSchema } from "@inlang/sdk"
-import { getSelectedBundleByBundleIdOrAlias } from "../../helper.js"
 import { msg } from "../../messages/msg.js"
-import { state } from "../../state.js"
 import type { UpdateBundleMessage } from "../editorView.js"
 import type { Kysely } from "kysely"
 
@@ -26,7 +24,8 @@ export async function handleUpdateBundle({
 		}
 
 		if (change.newData) {
-			db.insertInto(change.entity)
+			await db
+				.insertInto(change.entity)
 				.values({
 					...change.newData,
 					// @ts-expect-error - we need to remove the nesting

--- a/src/utilities/editor/sherlock-editor-app/src/components/Editor.tsx
+++ b/src/utilities/editor/sherlock-editor-app/src/components/Editor.tsx
@@ -65,9 +65,17 @@ const Editor: React.FC<{
 	bundle: BundleNested
 	settings: ProjectSettings
 }> = ({ bundle, settings }) => {
-	const handleChangeEvent = (e: Event) => {
+	const handleChangeEvent = (e: Event, persist = false) => {
 		const change = (e as CustomEvent).detail as ChangeEventDetail
-		vscode.postMessage({ command: "change", change })
+		vscode.postMessage({ command: "change", change, persist })
+	}
+
+	const handleStructuralChangeEvent = (e: Event) => {
+		handleChangeEvent(e, true)
+	}
+
+	const handlePersistEdit = () => {
+		vscode.postMessage({ command: "persist-edit" })
 	}
 
 	const handleDelete = ({
@@ -112,7 +120,11 @@ const Editor: React.FC<{
 							>
 								{message.variants.map((variant) => (
 									<ReactInlangVariant key={variant.id} slot="variant" variant={variant}>
-										<ReactInlangPatternEditor slot="pattern-editor" variant={variant} />
+										<ReactInlangPatternEditor
+											slot="pattern-editor"
+											variant={variant}
+											onPatternEditorBlur={handlePersistEdit}
+										/>
 										<SlDropdown
 											slot="variant-action"
 											className="animate-blendIn"
@@ -243,7 +255,7 @@ const Editor: React.FC<{
 				label="Add selector"
 			>
 				<ReactInlangAddSelector
-					change={handleChangeEvent}
+					change={handleStructuralChangeEvent}
 					onSubmit={() => {
 						const dialog = document.getElementById(
 							`selector-button-dialog-${bundle.id}`

--- a/test/specs/issue-198-edit-view.e2e.test.ts
+++ b/test/specs/issue-198-edit-view.e2e.test.ts
@@ -1,0 +1,144 @@
+import { browser, expect } from "@wdio/globals"
+import fs from "node:fs/promises"
+import path from "node:path"
+import vscode from "vscode"
+import {} from "wdio-vscode-service"
+
+const workspacePath =
+	process.env.SHERLOCK_E2E_WORKSPACE ?? path.join(process.cwd(), "examples/minimal")
+const enMessagesPath = path.join(workspacePath, "messages/en.json")
+const deMessagesPath = path.join(workspacePath, "messages/de.json")
+const originalEnMessages = {
+	hello_world: "Hello world",
+	welcome_user: "Welcome, {name}!",
+	missing_in_german: "This message is intentionally missing in German",
+}
+const originalDeMessages = {
+	hello_world: "Hallo Welt",
+	welcome_user: "Willkommen, {name}!",
+}
+
+async function writeJson(filePath: string, messages: Record<string, string>) {
+	await fs.writeFile(filePath, `${JSON.stringify(messages, undefined, "\t")}\n`)
+}
+
+async function resetMessages() {
+	await writeJson(enMessagesPath, originalEnMessages)
+	await writeJson(deMessagesPath, originalDeMessages)
+}
+
+async function readEnMessages() {
+	return JSON.parse(await fs.readFile(enMessagesPath, "utf8")) as Record<string, string>
+}
+
+async function readDeMessages() {
+	return JSON.parse(await fs.readFile(deMessagesPath, "utf8")) as Record<string, string>
+}
+
+describe("Issue #198: edit view fields accept normal text edits", () => {
+	beforeEach(async () => {
+		await resetMessages()
+	})
+
+	afterEach(async () => {
+		await resetMessages()
+	})
+
+	it("persists typing, backspace, and paste in existing and empty translation fields", async () => {
+		const workbench = await browser.getWorkbench()
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+			await extension?.activate()
+			await vscodeApi.commands.executeCommand("sherlock.reloadProject")
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "hello_world",
+			})
+		})
+
+		const webview = await workbench.getWebviewByTitle("hello_world")
+		await webview.open()
+
+		const editor = await $("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		await editor.waitForDisplayed({ timeout: 30_000 })
+		await expect(editor).toHaveText("Hello world")
+
+		await editor.click()
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "a"])
+		await browser.keys("Editable textx")
+		await browser.keys("Backspace")
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode, text: string) => {
+			await vscodeApi.env.clipboard.writeText(text)
+		}, " pasted")
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "v"])
+		await browser.waitUntil(async () => (await editor.getText()) === "Editable text pasted", {
+			timeout: 5_000,
+			timeoutMsg: "Expected the existing translation editor to contain pasted text",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readEnMessages()
+				return messages.hello_world === "Editable text pasted"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected edit-view text changes to be saved to messages/en.json",
+			}
+		)
+
+		await webview.close()
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "missing_in_german",
+			})
+		})
+
+		const missingWebview = await workbench.getWebviewByTitle("missing_in_german")
+		await missingWebview.open()
+
+		const addGermanMessage = await $("p=Add de")
+		await addGermanMessage.waitForDisplayed({ timeout: 30_000 })
+		await addGermanMessage.click()
+
+		await browser.waitUntil(async () => (await $$("inlang-pattern-editor")).length === 2, {
+			timeout: 10_000,
+			timeoutMsg: "Expected adding German to render a second pattern editor",
+		})
+
+		const editors = await $$("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		const germanEditor = editors[1]
+		expect(germanEditor).toBeDefined()
+		await germanEditor.click()
+		await browser.keys("Deutschx")
+		await browser.keys("Backspace")
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode, text: string) => {
+			await vscodeApi.env.clipboard.writeText(text)
+		}, " pasted")
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "v"])
+		await browser.waitUntil(async () => (await germanEditor.getText()) === "Deutsch pasted", {
+			timeout: 5_000,
+			timeoutMsg: "Expected the empty German editor to accept typed and pasted text",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readDeMessages()
+				return messages.missing_in_german === "Deutsch pasted"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected empty non-base locale edits to be saved to messages/de.json",
+			}
+		)
+
+		await missingWebview.close()
+
+		expect((await readEnMessages()).hello_world).toBe("Editable text pasted")
+		expect((await readDeMessages()).missing_in_german).toBe("Deutsch pasted")
+	})
+})

--- a/test/specs/test-environment.e2e.test.ts
+++ b/test/specs/test-environment.e2e.test.ts
@@ -3,11 +3,11 @@ import vscode from "vscode"
 import {} from "wdio-vscode-service"
 
 describe("Visual Studio Code extension (Sherlock) E2E Testing Environment", () => {
-	it("should be able to load Visual Studio Code with inlang example code", async () => {
+	it("should be able to load Visual Studio Code with the minimal Sherlock example", async () => {
 		const workbench = await browser.getWorkbench()
 		const title = await workbench.getTitleBar().getTitle()
 		expect(title).toContain("[Extension Development Host]")
-		expect(title).toContain("inlang")
+		expect(title).toContain("minimal")
 	})
 
 	it("should load and install our Visual Studio Code extension (Sherlock)", async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["./spec/**/*.e2e.test.ts", "./wdio.conf.ts"],
+	"include": ["./specs/**/*.e2e.test.ts", "./wdio.conf.ts"],
 	"compilerOptions": {
 		"module": "ESNext",
 		"types": [
@@ -12,6 +12,7 @@
 		"target": "es2022",
 		"moduleResolution": "node",
 		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"experimentalDecorators": true
 	}
 }

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -1,9 +1,22 @@
 import type { Options } from "@wdio/types"
+import fs from "node:fs"
+import os from "node:os"
 import url from "node:url"
 import path from "node:path"
 
 const debug = process.env.DEBUG
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url))
+const fixtureWorkspacePath = path.join(__dirname, "../examples/minimal")
+const providedWorkspacePath = process.env.SHERLOCK_E2E_WORKSPACE
+const tempWorkspaceRoot = providedWorkspacePath
+	? undefined
+	: fs.mkdtempSync(path.join(os.tmpdir(), "sherlock-e2e-"))
+const e2eWorkspacePath = providedWorkspacePath ?? path.join(tempWorkspaceRoot!, "minimal")
+
+if (!providedWorkspacePath) {
+	fs.cpSync(fixtureWorkspacePath, e2eWorkspacePath, { recursive: true })
+	process.env.SHERLOCK_E2E_WORKSPACE = e2eWorkspacePath
+}
 
 export const config: Options.Testrunner = {
 	//
@@ -58,7 +71,7 @@ export const config: Options.Testrunner = {
 	// and 30 processes will get spawned. The property handles how many capabilities
 	// from the same test should run tests.
 	//
-	maxInstances: debug ? 1 : 10,
+	maxInstances: 1,
 	//
 	// If you have trouble getting all important capabilities together, check out the
 	// Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -67,12 +80,12 @@ export const config: Options.Testrunner = {
 	capabilities: [
 		{
 			browserName: "vscode",
-			browserVersion: "1.86.2", // also possible: "insiders", "stable" or a specific version e.g. "1.80.0"
+			browserVersion: "stable", // also possible: "insiders" or a specific version e.g. "1.80.0"
 			"wdio:vscodeOptions": {
 				verboseLogging: false,
 				// points to directory where extension package.json is located
 				extensionPath: path.join(__dirname, ".."),
-				workspacePath: path.join(__dirname, "../../../development-projects/inlang-nextjs"),
+				workspacePath: e2eWorkspacePath,
 				// optional VS Code settings
 				userSettings: {
 					"editor.fontSize": 14,
@@ -299,6 +312,11 @@ export const config: Options.Testrunner = {
 	 */
 	// onComplete: function(exitCode, config, capabilities, results) {
 	// },
+	onComplete: function () {
+		if (tempWorkspaceRoot) {
+			fs.rmSync(tempWorkspaceRoot, { recursive: true, force: true })
+		}
+	},
 	/**
 	 * Gets executed when a refresh happens.
 	 * @param {string} oldSessionId session ID of the old session


### PR DESCRIPTION
## Summary
- prevent edit-view text changes from refreshing the active webview on every keystroke
- queue editor DB updates before blur/dispose persistence so the final edit is saved
- refresh and persist structural editor changes while keeping text edits stable during typing
- add e2e coverage for existing and empty translation fields

Fixes https://github.com/opral/sherlock/issues/198

## Validation
- pnpm build
- pnpm test
- pnpm exec tsc -p test/tsconfig.json --noEmit
- pnpm test:e2e
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when translation edits hit the DB and disk versus UI refresh; incorrect timing could still lose edits or leave stale UI, though scope is limited to the editor webview path.
> 
> **Overview**
> Fixes edit-view translation fields losing or failing to save text when typing, deleting, or pasting (#198).
> 
> **Text edits** now only queue in-memory DB updates via `change` messages with `persist: false`, so the webview is **not** reloaded on every keystroke. Saving to disk and firing edit events happens on **blur** (`persist-edit` from the pattern editor) and when the panel **closes**, after any queued updates finish.
> 
> **Structural edits** (e.g. add selector) still send `persist: true`, which refreshes the webview and runs the full `updateView` save path. Bundle DB writes in `handleUpdateBundle` are now properly **awaited**.
> 
> E2E setup moves to the **minimal** example workspace (optional temp copy), adds an **issue #198** spec for existing and newly added locale fields, and tightens WDIO config (`maxInstances: 1`, stable VS Code).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 369575b95d449934c4e88609dee68e099cb8fe21. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->