### PR TITLE
[codex] keep deleted translations deleted

### DIFF
--- a/.changeset/fix-edit-view-inputs.md
+++ b/.changeset/fix-edit-view-inputs.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Fix edit view text input so typing, deleting, and pasting in translation fields persists correctly.

--- a/.changeset/keep-deleted-translations-deleted.md
+++ b/.changeset/keep-deleted-translations-deleted.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Keep manually deleted translation keys from being restored on the next Sherlock save.

--- a/src/main.ts
+++ b/src/main.ts
@@ -22,6 +22,8 @@ import { linterDiagnostics } from "./diagnostics/linterDiagnostics.js"
 import { setupDirectMessageWatcher } from "./utilities/fs/experimental/directMessageHandler.js"
 //import { initErrorMonitoring } from "./services/error-monitoring/implementation.js"
 
+const messageFileSnapshots = new Map<string, Set<string>>()
+
 // Entry Point
 export async function activate(
 	context: vscode.ExtensionContext
@@ -99,11 +101,12 @@ export async function main(args: {
 		// Set up both file system watchers
 		// setupFileSystemWatcher(args)
 
-		// Set up direct message watcher as a fallback
-		setupDirectMessageWatcher({
-			context: args.context,
-			workspaceFolder: args.workspaceFolder,
-		})
+			// Set up direct message watcher as a fallback
+			await seedMessageFileSnapshots()
+			await setupDirectMessageWatcher({
+				context: args.context,
+				workspaceFolder: args.workspaceFolder,
+			})
 
 		return
 	} else {
@@ -173,6 +176,8 @@ async function setProjects(args: { workspaceFolder: vscode.WorkspaceFolder }) {
 export async function saveProject() {
 	try {
 		if (state().selectedProjectPath && state().project) {
+			await removeMessagesDeletedFromJsonFiles()
+
 			await saveProjectToDirectory({
 				fs: createFileSystemMapper(state().selectedProjectPath, fs),
 				project: state().project,
@@ -181,5 +186,126 @@ export async function saveProject() {
 		}
 	} catch (error) {
 		handleError(error)
+	}
+}
+
+async function removeMessagesDeletedFromJsonFiles() {
+	const project = state().project
+	const selectedProjectPath = state().selectedProjectPath
+	if (!project || !selectedProjectPath) return
+
+	const settings = await project.settings.get()
+	const baseLocale = settings.baseLocale ?? settings.locales[0]
+	const pathPattern = getJsonPathPattern(settings)
+	if (!pathPattern || !baseLocale) return
+
+	for (const locale of settings.locales) {
+		const messageFilePath = getMessageFilePath(selectedProjectPath, pathPattern, locale)
+		const currentKeys = await readMessageFileKeys(messageFilePath)
+		if (!currentKeys) continue
+
+		const previousKeys = messageFileSnapshots.get(messageFilePath)
+		if (!previousKeys) {
+			messageFileSnapshots.set(messageFilePath, currentKeys)
+			continue
+		}
+
+		const deletedKeys = [...previousKeys].filter((key) => !currentKeys.has(key))
+		for (const key of deletedKeys) {
+			if (locale === baseLocale) {
+				await deleteBundleMessages(key)
+			} else {
+				await deleteLocaleMessage(key, locale)
+			}
+		}
+
+		messageFileSnapshots.set(messageFilePath, currentKeys)
+	}
+
+	async function deleteBundleMessages(bundleId: string) {
+		const messages = await project.db
+			.selectFrom("message")
+			.select("id")
+			.where("bundleId", "=", bundleId)
+			.execute()
+
+		for (const message of messages) {
+			await project.db.deleteFrom("variant").where("messageId", "=", message.id).execute()
+		}
+
+		await project.db.deleteFrom("message").where("bundleId", "=", bundleId).execute()
+		await project.db.deleteFrom("bundle").where("id", "=", bundleId).execute()
+	}
+
+	async function deleteLocaleMessage(bundleId: string, locale: string) {
+		const messages = await project.db
+			.selectFrom("message")
+			.select("id")
+			.where("bundleId", "=", bundleId)
+			.where("locale", "=", locale)
+			.execute()
+
+		for (const message of messages) {
+			await project.db.deleteFrom("variant").where("messageId", "=", message.id).execute()
+		}
+
+		await project.db
+			.deleteFrom("message")
+			.where("bundleId", "=", bundleId)
+			.where("locale", "=", locale)
+			.execute()
+
+		const remainingMessages = await project.db
+			.selectFrom("message")
+			.select("id")
+			.where("bundleId", "=", bundleId)
+			.execute()
+
+		if (remainingMessages.length === 0) {
+			await project.db.deleteFrom("bundle").where("id", "=", bundleId).execute()
+		}
+	}
+}
+
+async function seedMessageFileSnapshots() {
+	const project = state().project
+	const selectedProjectPath = state().selectedProjectPath
+	if (!project || !selectedProjectPath) return
+
+	const settings = await project.settings.get()
+	const pathPattern = getJsonPathPattern(settings)
+	if (!pathPattern) return
+
+	for (const locale of settings.locales) {
+		const messageFilePath = getMessageFilePath(selectedProjectPath, pathPattern, locale)
+		const keys = await readMessageFileKeys(messageFilePath)
+		if (keys) {
+			messageFileSnapshots.set(messageFilePath, keys)
+		}
+	}
+}
+
+function getJsonPathPattern(settings: Awaited<ReturnType<NonNullable<typeof state>["project"]["settings"]["get"]>>) {
+	const pathPattern =
+		(settings as any)["plugin.inlang.json"]?.pathPattern ??
+		(settings as any)["plugin.inlang.messageFormat"]?.pathPattern
+
+	return typeof pathPattern === "string" ? pathPattern : undefined
+}
+
+function getMessageFilePath(selectedProjectPath: string, pathPattern: string, locale: string) {
+	const projectDirectory = path.dirname(selectedProjectPath)
+	return path.resolve(
+		projectDirectory,
+		pathPattern.replace("{languageTag}", locale).replace("{locale}", locale)
+	)
+}
+
+async function readMessageFileKeys(messageFilePath: string) {
+	try {
+		const file = JSON.parse(await fs.readFile(messageFilePath, "utf8"))
+		return new Set(Object.keys(file).filter((key) => key !== "$schema"))
+	} catch {
+		return undefined
 	}
 }

--- a/src/utilities/editor/editorView.ts
+++ b/src/utilities/editor/editorView.ts
@@ -18,6 +18,7 @@ import { saveProject } from "../../main.js"
 export interface UpdateBundleMessage {
 	command: string
 	change: ChangeEventDetail
+	persist?: boolean
 }
 
 /**
@@ -39,6 +40,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 	let panel: WebviewPanel | undefined
 	let disposables: Disposable[] = []
 	let bundleId = initialBundleId
+	let pendingUpdate = Promise.resolve()
 
 	/**
 	 * Opens a new panel if none is open, otherwise reveals the existing one.
@@ -64,6 +66,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		// Set up disposal
 		panel.onDidDispose(
 			() => {
+				void persistEdit()
 				dispose()
 				panel = undefined
 			},
@@ -119,7 +122,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						message: message.message,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "delete-variant":
 					await deleteVariant({
@@ -127,7 +130,7 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						variantId: message.id,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "delete-bundle":
 					await deleteBundleNested({
@@ -135,15 +138,17 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 						bundleId: message.id,
 					})
 
-					updateView()
+					await updateView()
 					return
 				case "change":
-					await handleUpdateBundle({
-						db: state().project?.db,
-						message,
-					})
+					await queueUpdate(message)
 
-					updateView()
+					if (message.persist === true) {
+						await updateView()
+					}
+					return
+				case "persist-edit":
+					await persistEdit()
 					return
 				case "show-info-message":
 					msg(message.message, "info", "statusBar", vscode.StatusBarAlignment.Right, 3000)
@@ -159,10 +164,22 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		disposables.push(disposable)
 	}
 
+	function queueUpdate(message: UpdateBundleMessage) {
+		pendingUpdate = pendingUpdate.then(() =>
+			handleUpdateBundle({
+				db: state().project?.db,
+				message,
+			})
+		)
+		return pendingUpdate
+	}
+
 	/**
 	 * Update view
 	 */
 	async function updateView() {
+		await pendingUpdate
+
 		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 		CONFIGURATION.EVENTS.ON_DID_EDITOR_VIEW_CHANGE.fire()
 
@@ -173,6 +190,22 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 				settings: await state().project?.settings.get(),
 			},
 		})
+
+		const workspaceFolder = vscode.workspace.workspaceFolders![0]
+		if (workspaceFolder) {
+			try {
+				await saveProject()
+			} catch (error) {
+				console.error("Failed to save project", error)
+				msg(`Failed to save project. ${String(error)}`, "error")
+			}
+		}
+	}
+
+	async function persistEdit() {
+		await pendingUpdate
+
+		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 
 		const workspaceFolder = vscode.workspace.workspaceFolders![0]
 		if (workspaceFolder) {

--- a/src/utilities/editor/helper/handleBundleUpdate.ts
+++ b/src/utilities/editor/helper/handleBundleUpdate.ts
@@ -1,7 +1,5 @@
 import type { InlangDatabaseSchema } from "@inlang/sdk"
-import { getSelectedBundleByBundleIdOrAlias } from "../../helper.js"
 import { msg } from "../../messages/msg.js"
-import { state } from "../../state.js"
 import type { UpdateBundleMessage } from "../editorView.js"
 import type { Kysely } from "kysely"
 
@@ -26,7 +24,8 @@ export async function handleUpdateBundle({
 		}
 
 		if (change.newData) {
-			db.insertInto(change.entity)
+			await db
+				.insertInto(change.entity)
 				.values({
 					...change.newData,
 					// @ts-expect-error - we need to remove the nesting

--- a/src/utilities/editor/sherlock-editor-app/src/components/Editor.tsx
+++ b/src/utilities/editor/sherlock-editor-app/src/components/Editor.tsx
@@ -65,9 +65,17 @@ const Editor: React.FC<{
 	bundle: BundleNested
 	settings: ProjectSettings
 }> = ({ bundle, settings }) => {
-	const handleChangeEvent = (e: Event) => {
+	const handleChangeEvent = (e: Event, persist = false) => {
 		const change = (e as CustomEvent).detail as ChangeEventDetail
-		vscode.postMessage({ command: "change", change })
+		vscode.postMessage({ command: "change", change, persist })
+	}
+
+	const handleStructuralChangeEvent = (e: Event) => {
+		handleChangeEvent(e, true)
+	}
+
+	const handlePersistEdit = () => {
+		vscode.postMessage({ command: "persist-edit" })
 	}
 
 	const handleDelete = ({
@@ -112,7 +120,11 @@ const Editor: React.FC<{
 							>
 								{message.variants.map((variant) => (
 									<ReactInlangVariant key={variant.id} slot="variant" variant={variant}>
-										<ReactInlangPatternEditor slot="pattern-editor" variant={variant} />
+										<ReactInlangPatternEditor
+											slot="pattern-editor"
+											variant={variant}
+											onPatternEditorBlur={handlePersistEdit}
+										/>
 										<SlDropdown
 											slot="variant-action"
 											className="animate-blendIn"
@@ -243,7 +255,7 @@ const Editor: React.FC<{
 				label="Add selector"
 			>
 				<ReactInlangAddSelector
-					change={handleChangeEvent}
+					change={handleStructuralChangeEvent}
 					onSubmit={() => {
 						const dialog = document.getElementById(
 							`selector-button-dialog-${bundle.id}`

--- a/src/utilities/fs/experimental/directMessageHandler.ts
+++ b/src/utilities/fs/experimental/directMessageHandler.ts
@@ -23,7 +23,6 @@ const fileMessageKeys = new Map<string, Set<string>>()
 const DEBOUNCE_MS = 150 // Reduced debounce time for faster updates
 const processingFiles = new Set<string>() // Prevent concurrent processing of the same file
 const lastFileUpdateTime = new Map<string, number>() // Track when files were last processed
-const FILE_UPDATE_COOLDOWN_MS = 1000 // Reduced cooldown to make the editor more responsive
 let isInEventLoop = false // Global flag to detect event loops
 let lastUIUpdateTime = 0 // Track when we last fired UI update events
 const MIN_UI_UPDATE_INTERVAL_MS = 300 // Minimum time between UI updates to prevent UI lag
@@ -161,6 +160,13 @@ export async function setupDirectMessageWatcher(args: {
 
 		console.log("Created message watcher for pattern: **/messages/*.json")
 
+		const messageFiles = await vscode.workspace.findFiles(messagePattern)
+		for (const uri of messageFiles) {
+			const filePath = uri.fsPath
+			fileHashes.set(filePath, await getFileHash(uri))
+			fileMessageKeys.set(filePath, await extractMessageKeys(uri))
+		}
+
 		// Create debounced handler for message file events
 		const debouncedHandleMessageEvent = debounce(async (uri: vscode.Uri, eventType: string) => {
 			const filePath = uri.fsPath
@@ -171,19 +177,9 @@ export async function setupDirectMessageWatcher(args: {
 				return
 			}
 
-			// Check cooldown period to prevent rapid-fire updates to the same file
-			const now = Date.now()
-			const lastUpdate = lastFileUpdateTime.get(filePath) || 0
-			if (now - lastUpdate < FILE_UPDATE_COOLDOWN_MS) {
-				console.log(
-					`File ${filePath} was updated too recently, skipping (cooldown: ${FILE_UPDATE_COOLDOWN_MS}ms)`
-				)
-				return
-			}
-
-			// Check if we're in an event loop
-			if (isInEventLoop) {
-				console.log("Detected potential event loop, breaking the cycle")
+				// Check if we're in an event loop
+				if (isInEventLoop) {
+					console.log("Detected potential event loop, breaking the cycle")
 				return
 			}
 
@@ -230,10 +226,12 @@ export async function setupDirectMessageWatcher(args: {
 					return
 				}
 
-				// Get current plugins and find message format plugin
+				// Get current plugins and find a JSON-capable message import plugin
 				const currentPlugins = await currentProject.plugins.get()
 				const messageFormatPlugin = currentPlugins.find((p) =>
-					(p.key || p.id || "").toLowerCase().includes("messageformat")
+					["messageformat", "json"].some((pluginName) =>
+						(p.key || p.id || "").toLowerCase().includes(pluginName)
+					)
 				)
 
 				if (!messageFormatPlugin) {
@@ -252,8 +250,8 @@ export async function setupDirectMessageWatcher(args: {
 				if (eventType !== "Deleted") {
 					// Extract current message keys from file
 					const currentKeys = await extractMessageKeys(uri)
-					// Get previously known keys (if any)
-					const previousKeys = fileMessageKeys.get(filePath) || new Set()
+					// Deletions are only safe to infer from a previous snapshot of this file.
+					const previousKeys = fileMessageKeys.get(filePath) ?? new Set()
 
 					// Find keys that have been deleted (present in previous but not in current)
 					const deletedKeys = new Set([...previousKeys].filter((key) => !currentKeys.has(key)))
@@ -317,7 +315,7 @@ export async function setupDirectMessageWatcher(args: {
 					console.log(`File deleted: ${filePath} - handling deletion for locale ${locale}`)
 
 					// When a file is deleted, all its messages should be removed for that locale
-					const previousKeys = fileMessageKeys.get(filePath) || new Set()
+					const previousKeys = fileMessageKeys.get(filePath) ?? new Set()
 
 					if (previousKeys.size > 0) {
 						// Track if we've made changes to update the UI

--- a/test/specs/issue-186-deleted-translations.e2e.test.ts
+++ b/test/specs/issue-186-deleted-translations.e2e.test.ts
@@ -1,0 +1,163 @@
+import { browser, expect } from "@wdio/globals"
+import fs from "node:fs/promises"
+import path from "node:path"
+import vscode from "vscode"
+import {} from "wdio-vscode-service"
+
+const workspacePath =
+	process.env.SHERLOCK_E2E_WORKSPACE ?? path.join(process.cwd(), "examples/minimal")
+const enMessagesPath = path.join(workspacePath, "messages/en.json")
+const deMessagesPath = path.join(workspacePath, "messages/de.json")
+const originalEnMessages = {
+	hello_world: "Hello world",
+	welcome_user: "Welcome, {name}!",
+	missing_in_german: "This message is intentionally missing in German",
+}
+const originalDeMessages = {
+	hello_world: "Hallo Welt",
+	welcome_user: "Willkommen, {name}!",
+}
+
+async function writeJson(filePath: string, messages: Record<string, string>) {
+	await fs.writeFile(filePath, `${JSON.stringify(messages, undefined, "\t")}\n`)
+}
+
+async function resetMessages() {
+	await writeJson(enMessagesPath, originalEnMessages)
+	await writeJson(deMessagesPath, originalDeMessages)
+}
+
+async function readEnMessages() {
+	return JSON.parse(await fs.readFile(enMessagesPath, "utf8")) as Record<string, string>
+}
+
+async function readDeMessages() {
+	return JSON.parse(await fs.readFile(deMessagesPath, "utf8")) as Record<string, string>
+}
+
+async function activateAndReloadProject() {
+	await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+		const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+		await extension?.activate()
+		await vscodeApi.commands.executeCommand("sherlock.reloadProject")
+	})
+}
+
+describe("Issue #186: deleted translations stay deleted", () => {
+	beforeEach(async () => {
+		await resetMessages()
+	})
+
+	afterEach(async () => {
+		await resetMessages()
+	})
+
+	it("does not restore a manually deleted message key on the next Sherlock save", async () => {
+		const workbench = await browser.getWorkbench()
+
+		await activateAndReloadProject()
+
+		const messagesAfterDelete = { ...originalEnMessages }
+		delete messagesAfterDelete.missing_in_german
+		await writeJson(enMessagesPath, messagesAfterDelete)
+
+		await browser.waitUntil(async () => !("missing_in_german" in (await readEnMessages())), {
+			timeout: 5_000,
+			timeoutMsg: "Expected the manually deleted key to be absent from messages/en.json",
+		})
+		await browser.pause(1500)
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "hello_world",
+			})
+		})
+
+		const webview = await workbench.getWebviewByTitle("hello_world")
+		await webview.open()
+
+		const editor = await $("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		await editor.waitForDisplayed({ timeout: 30_000 })
+		await expect(editor).toHaveText("Hello world")
+
+		await editor.click()
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "a"])
+		await browser.keys("Hello after deletion")
+		await browser.waitUntil(async () => (await editor.getText()) === "Hello after deletion", {
+			timeout: 5_000,
+			timeoutMsg: "Expected unrelated edit-view text change to apply",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readEnMessages()
+				return messages.hello_world === "Hello after deletion"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected the unrelated edit-view change to be saved",
+			}
+		)
+
+		await webview.close()
+
+		const messages = await readEnMessages()
+		expect(messages.hello_world).toBe("Hello after deletion")
+		expect(messages).not.toHaveProperty("missing_in_german")
+	})
+
+	it("does not restore a manually deleted target-locale translation on the next Sherlock save", async () => {
+		const workbench = await browser.getWorkbench()
+
+		await activateAndReloadProject()
+
+		const germanMessagesAfterDelete = { ...originalDeMessages }
+		delete germanMessagesAfterDelete.welcome_user
+		await writeJson(deMessagesPath, germanMessagesAfterDelete)
+
+		await browser.waitUntil(async () => !("welcome_user" in (await readDeMessages())), {
+			timeout: 5_000,
+			timeoutMsg: "Expected the manually deleted German key to be absent from messages/de.json",
+		})
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "hello_world",
+			})
+		})
+
+		const webview = await workbench.getWebviewByTitle("hello_world")
+		await webview.open()
+
+		const editor = await $("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		await editor.waitForDisplayed({ timeout: 30_000 })
+		await expect(editor).toHaveText("Hello world")
+
+		await editor.click()
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "a"])
+		await browser.keys("Hello after German deletion")
+		await browser.waitUntil(async () => (await editor.getText()) === "Hello after German deletion", {
+			timeout: 5_000,
+			timeoutMsg: "Expected unrelated edit-view text change to apply",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readEnMessages()
+				return messages.hello_world === "Hello after German deletion"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected the unrelated edit-view change to be saved",
+			}
+		)
+
+		await webview.close()
+
+		const germanMessages = await readDeMessages()
+		expect(germanMessages.hello_world).toBe("Hallo Welt")
+		expect(germanMessages).not.toHaveProperty("welcome_user")
+	})
+})

--- a/test/specs/issue-198-edit-view.e2e.test.ts
+++ b/test/specs/issue-198-edit-view.e2e.test.ts
@@ -1,0 +1,144 @@
+import { browser, expect } from "@wdio/globals"
+import fs from "node:fs/promises"
+import path from "node:path"
+import vscode from "vscode"
+import {} from "wdio-vscode-service"
+
+const workspacePath =
+	process.env.SHERLOCK_E2E_WORKSPACE ?? path.join(process.cwd(), "examples/minimal")
+const enMessagesPath = path.join(workspacePath, "messages/en.json")
+const deMessagesPath = path.join(workspacePath, "messages/de.json")
+const originalEnMessages = {
+	hello_world: "Hello world",
+	welcome_user: "Welcome, {name}!",
+	missing_in_german: "This message is intentionally missing in German",
+}
+const originalDeMessages = {
+	hello_world: "Hallo Welt",
+	welcome_user: "Willkommen, {name}!",
+}
+
+async function writeJson(filePath: string, messages: Record<string, string>) {
+	await fs.writeFile(filePath, `${JSON.stringify(messages, undefined, "\t")}\n`)
+}
+
+async function resetMessages() {
+	await writeJson(enMessagesPath, originalEnMessages)
+	await writeJson(deMessagesPath, originalDeMessages)
+}
+
+async function readEnMessages() {
+	return JSON.parse(await fs.readFile(enMessagesPath, "utf8")) as Record<string, string>
+}
+
+async function readDeMessages() {
+	return JSON.parse(await fs.readFile(deMessagesPath, "utf8")) as Record<string, string>
+}
+
+describe("Issue #198: edit view fields accept normal text edits", () => {
+	beforeEach(async () => {
+		await resetMessages()
+	})
+
+	afterEach(async () => {
+		await resetMessages()
+	})
+
+	it("persists typing, backspace, and paste in existing and empty translation fields", async () => {
+		const workbench = await browser.getWorkbench()
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+			await extension?.activate()
+			await vscodeApi.commands.executeCommand("sherlock.reloadProject")
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "hello_world",
+			})
+		})
+
+		const webview = await workbench.getWebviewByTitle("hello_world")
+		await webview.open()
+
+		const editor = await $("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		await editor.waitForDisplayed({ timeout: 30_000 })
+		await expect(editor).toHaveText("Hello world")
+
+		await editor.click()
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "a"])
+		await browser.keys("Editable textx")
+		await browser.keys("Backspace")
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode, text: string) => {
+			await vscodeApi.env.clipboard.writeText(text)
+		}, " pasted")
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "v"])
+		await browser.waitUntil(async () => (await editor.getText()) === "Editable text pasted", {
+			timeout: 5_000,
+			timeoutMsg: "Expected the existing translation editor to contain pasted text",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readEnMessages()
+				return messages.hello_world === "Editable text pasted"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected edit-view text changes to be saved to messages/en.json",
+			}
+		)
+
+		await webview.close()
+
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			await vscodeApi.commands.executeCommand("sherlock.openEditorView", {
+				bundleId: "missing_in_german",
+			})
+		})
+
+		const missingWebview = await workbench.getWebviewByTitle("missing_in_german")
+		await missingWebview.open()
+
+		const addGermanMessage = await $("p=Add de")
+		await addGermanMessage.waitForDisplayed({ timeout: 30_000 })
+		await addGermanMessage.click()
+
+		await browser.waitUntil(async () => (await $$("inlang-pattern-editor")).length === 2, {
+			timeout: 10_000,
+			timeoutMsg: "Expected adding German to render a second pattern editor",
+		})
+
+		const editors = await $$("inlang-pattern-editor .inlang-pattern-editor-contenteditable")
+		const germanEditor = editors[1]
+		expect(germanEditor).toBeDefined()
+		await germanEditor.click()
+		await browser.keys("Deutschx")
+		await browser.keys("Backspace")
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode, text: string) => {
+			await vscodeApi.env.clipboard.writeText(text)
+		}, " pasted")
+		await browser.keys([process.platform === "darwin" ? "Meta" : "Control", "v"])
+		await browser.waitUntil(async () => (await germanEditor.getText()) === "Deutsch pasted", {
+			timeout: 5_000,
+			timeoutMsg: "Expected the empty German editor to accept typed and pasted text",
+		})
+		await browser.keys("Tab")
+
+		await browser.waitUntil(
+			async () => {
+				const messages = await readDeMessages()
+				return messages.missing_in_german === "Deutsch pasted"
+			},
+			{
+				timeout: 5_000,
+				timeoutMsg: "Expected empty non-base locale edits to be saved to messages/de.json",
+			}
+		)
+
+		await missingWebview.close()
+
+		expect((await readEnMessages()).hello_world).toBe("Editable text pasted")
+		expect((await readDeMessages()).missing_in_german).toBe("Deutsch pasted")
+	})
+})

--- a/test/specs/test-environment.e2e.test.ts
+++ b/test/specs/test-environment.e2e.test.ts
@@ -3,11 +3,11 @@ import vscode from "vscode"
 import {} from "wdio-vscode-service"
 
 describe("Visual Studio Code extension (Sherlock) E2E Testing Environment", () => {
-	it("should be able to load Visual Studio Code with inlang example code", async () => {
+	it("should be able to load Visual Studio Code with the minimal Sherlock example", async () => {
 		const workbench = await browser.getWorkbench()
 		const title = await workbench.getTitleBar().getTitle()
 		expect(title).toContain("[Extension Development Host]")
-		expect(title).toContain("inlang")
+		expect(title).toContain("minimal")
 	})
 
 	it("should load and install our Visual Studio Code extension (Sherlock)", async () => {

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,5 +1,5 @@
 {
-	"include": ["./spec/**/*.e2e.test.ts", "./wdio.conf.ts"],
+	"include": ["./specs/**/*.e2e.test.ts", "./wdio.conf.ts"],
 	"compilerOptions": {
 		"module": "ESNext",
 		"types": [
@@ -12,6 +12,7 @@
 		"target": "es2022",
 		"moduleResolution": "node",
 		"esModuleInterop": true,
+		"skipLibCheck": true,
 		"experimentalDecorators": true
 	}
 }

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -1,9 +1,22 @@
 import type { Options } from "@wdio/types"
+import fs from "node:fs"
+import os from "node:os"
 import url from "node:url"
 import path from "node:path"
 
 const debug = process.env.DEBUG
 const __dirname = url.fileURLToPath(new URL(".", import.meta.url))
+const fixtureWorkspacePath = path.join(__dirname, "../examples/minimal")
+const providedWorkspacePath = process.env.SHERLOCK_E2E_WORKSPACE
+const tempWorkspaceRoot = providedWorkspacePath
+	? undefined
+	: fs.mkdtempSync(path.join(os.tmpdir(), "sherlock-e2e-"))
+const e2eWorkspacePath = providedWorkspacePath ?? path.join(tempWorkspaceRoot!, "minimal")
+
+if (!providedWorkspacePath) {
+	fs.cpSync(fixtureWorkspacePath, e2eWorkspacePath, { recursive: true })
+	process.env.SHERLOCK_E2E_WORKSPACE = e2eWorkspacePath
+}
 
 export const config: Options.Testrunner = {
 	//
@@ -58,7 +71,7 @@ export const config: Options.Testrunner = {
 	// and 30 processes will get spawned. The property handles how many capabilities
 	// from the same test should run tests.
 	//
-	maxInstances: debug ? 1 : 10,
+	maxInstances: 1,
 	//
 	// If you have trouble getting all important capabilities together, check out the
 	// Sauce Labs platform configurator - a great tool to configure your capabilities:
@@ -67,12 +80,12 @@ export const config: Options.Testrunner = {
 	capabilities: [
 		{
 			browserName: "vscode",
-			browserVersion: "1.86.2", // also possible: "insiders", "stable" or a specific version e.g. "1.80.0"
+			browserVersion: "stable", // also possible: "insiders" or a specific version e.g. "1.80.0"
 			"wdio:vscodeOptions": {
 				verboseLogging: false,
 				// points to directory where extension package.json is located
 				extensionPath: path.join(__dirname, ".."),
-				workspacePath: path.join(__dirname, "../../../development-projects/inlang-nextjs"),
+				workspacePath: e2eWorkspacePath,
 				// optional VS Code settings
 				userSettings: {
 					"editor.fontSize": 14,
@@ -299,6 +312,11 @@ export const config: Options.Testrunner = {
 	 */
 	// onComplete: function(exitCode, config, capabilities, results) {
 	// },
+	onComplete: function () {
+		if (tempWorkspaceRoot) {
+			fs.rmSync(tempWorkspaceRoot, { recursive: true, force: true })
+		}
+	},
 	/**
 	 * Gets executed when a refresh happens.
 	 * @param {string} oldSessionId session ID of the old session


### PR DESCRIPTION
## Summary

- add e2e coverage for deleted translation keys staying deleted
- reconcile message JSON deletions from file snapshots before saving
- harden direct message watcher snapshots so missing translations are not mistaken for deletions

Closes https://github.com/opral/sherlock/issues/186

## Validation

- pnpm exec tsc -p test/tsconfig.json --noEmit
- pnpm build
- pnpm test
- pnpm exec wdio run ./test/wdio.conf.ts --spec ./test/specs/issue-186-deleted-translations.e2e.test.ts
- pnpm exec wdio run ./test/wdio.conf.ts --spec ./test/specs/issue-198-edit-view.e2e.test.ts
- pnpm test:e2e
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the save path and performs DB deletes for translation bundles/messages; behavior is covered by new E2E specs but incorrect snapshot logic could drop translations.
> 
> **Overview**
> Fixes two Sherlock UX bugs: **manually removed keys in locale JSON no longer come back** on the next save, and **edit-view translation fields** reliably keep typing, delete, and paste.
> 
> **Deleted translations:** `saveProject` now reconciles on-disk message JSON against seeded per-file key snapshots and removes matching bundles/messages from the project DB before `saveProjectToDirectory`. Startup seeds those snapshots; the direct message watcher preloads hashes/keys, drops the per-file cooldown, and only treats keys as deleted when they disappear from a prior snapshot (not on first sight).
> 
> **Edit view:** Webview `change` events update the DB through a serialized queue without saving or refreshing the panel on every keystroke. Persistence runs on pattern-editor blur, panel dispose, and structural edits (`persist: true`); `handleUpdateBundle` is awaited.
> 
> Adds E2E coverage for issues #186 and #198 and points WDIO at a copied `examples/minimal` workspace.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9b783ae9299568d87d53436fd07a769e5692e091. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->