### PR TITLE
[codex] Handle unreadable workspace folders

### DIFF
--- a/.changeset/eacces-workspace-discovery.md
+++ b/.changeset/eacces-workspace-discovery.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Handle unreadable workspace folders during project discovery.

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,0 +1,182 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import * as vscode from "vscode"
+import fg from "fast-glob"
+import { activate, discoverProjectsInWorkspace } from "./main.js"
+import { state } from "./utilities/state.js"
+import { handleError } from "./utilities/utils.js"
+import { gettingStartedView } from "./utilities/getting-started/gettingStarted.js"
+
+vi.mock("vscode", () => ({
+	version: "1.90.0",
+	commands: {
+		executeCommand: vi.fn(),
+		registerCommand: vi.fn(),
+	},
+	workspace: {
+		workspaceFolders: [],
+	},
+	window: {
+		registerTreeDataProvider: vi.fn(),
+		registerWebviewViewProvider: vi.fn(),
+		showErrorMessage: vi.fn(),
+	},
+	languages: {
+		registerCodeActionsProvider: vi.fn(),
+	},
+	EventEmitter: class {
+		fire = vi.fn()
+		event = vi.fn()
+	},
+	ThemeIcon: class {},
+	ThemeColor: class {},
+	TreeItemCollapsibleState: {
+		Collapsed: 0,
+		None: 1,
+		Expanded: 2,
+	},
+	CodeActionKind: {
+		QuickFix: "quickfix",
+	},
+}))
+
+vi.mock("fast-glob", () => ({
+	default: {
+		async: vi.fn(),
+		convertPathToPattern: vi.fn((path: string) => path),
+	},
+}))
+
+vi.mock("./configuration.js", () => ({
+	CONFIGURATION: {
+		COMMANDS: {},
+		FILES: {
+			PROJECT: "project.inlang/settings.json",
+		},
+	},
+}))
+
+vi.mock("./utilities/utils.js", () => ({
+	handleError: vi.fn(),
+}))
+
+vi.mock("./utilities/project/project.js", () => ({
+	projectView: vi.fn(),
+}))
+
+vi.mock("./decorations/messagePreview.js", () => ({
+	messagePreview: vi.fn(),
+}))
+
+vi.mock("./actions/extractMessage.js", () => ({
+	ExtractMessage: class {
+		static providedCodeActionKinds = []
+	},
+}))
+
+vi.mock("./utilities/errors/errors.js", () => ({
+	errorView: vi.fn(),
+}))
+
+vi.mock("./utilities/messages/messages.js", () => ({
+	messageView: vi.fn(),
+}))
+
+vi.mock("./utilities/fs/createFileSystemMapper.js", () => ({
+	createFileSystemMapper: vi.fn(),
+}))
+
+vi.mock("./utilities/getting-started/gettingStarted.js", () => ({
+	gettingStartedView: vi.fn(),
+}))
+
+vi.mock("./utilities/project/closestInlangProject.js", () => ({
+	closestInlangProject: vi.fn(),
+}))
+
+vi.mock("./utilities/recommendation/recommendation.js", () => ({
+	recommendationBannerView: vi.fn(),
+}))
+
+vi.mock("./services/telemetry/index.js", () => ({
+	capture: vi.fn(),
+	telemetry: {
+		capture: vi.fn(),
+	},
+}))
+
+vi.mock("./utilities/settings/statusBar.js", () => ({
+	statusBar: vi.fn(),
+}))
+
+vi.mock("./diagnostics/linterDiagnostics.js", () => ({
+	linterDiagnostics: vi.fn(),
+}))
+
+vi.mock("./utilities/fs/experimental/directMessageHandler.js", () => ({
+	setupDirectMessageWatcher: vi.fn(),
+}))
+
+vi.mock("@inlang/sdk", () => ({
+	saveProjectToDirectory: vi.fn(),
+}))
+
+describe("discoverProjectsInWorkspace", () => {
+	const workspaceFolder = {
+		uri: {
+			fsPath: "/workspace",
+		},
+	} as vscode.WorkspaceFolder
+
+	beforeEach(() => {
+		vi.clearAllMocks()
+		;(
+			vscode.workspace as unknown as { workspaceFolders: vscode.WorkspaceFolder[] }
+		).workspaceFolders = [workspaceFolder]
+	})
+
+	it("suppresses unreadable workspace directories during project discovery", async () => {
+		vi.mocked(fg.async).mockResolvedValueOnce(["/workspace/project.inlang"])
+
+		const projects = await discoverProjectsInWorkspace({ workspaceFolder })
+
+		expect(fg.async).toHaveBeenCalledWith(
+			"/workspace/**/*.inlang",
+			expect.objectContaining({
+				onlyDirectories: true,
+				ignore: ["**/node_modules/**"],
+				absolute: true,
+				cwd: "/workspace",
+				suppressErrors: true,
+			})
+		)
+		expect(projects).toEqual([
+			{
+				projectPath: "/workspace/project.inlang",
+			},
+		])
+	})
+
+	it("initializes an empty project list if discovery still fails", async () => {
+		const error = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+		vi.mocked(fg.async).mockRejectedValueOnce(error)
+
+		const projects = await discoverProjectsInWorkspace({ workspaceFolder })
+
+		expect(handleError).toHaveBeenCalledWith(error)
+		expect(projects).toEqual([])
+	})
+
+	it("falls back to Getting Started when activation discovery fails before state exists", async () => {
+		const error = Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" })
+		const context = {
+			subscriptions: [],
+		} as unknown as vscode.ExtensionContext
+		vi.mocked(fg.async).mockRejectedValueOnce(error)
+
+		await expect(activate(context)).resolves.toEqual({ context })
+
+		expect(handleError).toHaveBeenCalledWith(error)
+		expect(state().projectsInWorkspace).toEqual([])
+		expect(gettingStartedView).toHaveBeenCalledWith(expect.objectContaining({ workspaceFolder }))
+	})
+})

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,7 +2,7 @@ import * as vscode from "vscode"
 import { handleError } from "./utilities/utils.js"
 import { CONFIGURATION } from "./configuration.js"
 import { projectView } from "./utilities/project/project.js"
-import { setState, state } from "./utilities/state.js"
+import { setProjectsInWorkspace, setState, state } from "./utilities/state.js"
 import { messagePreview } from "./decorations/messagePreview.js"
 import { ExtractMessage } from "./actions/extractMessage.js"
 import { errorView } from "./utilities/errors/errors.js"
@@ -147,27 +147,30 @@ async function handleInlangErrors() {
 	}
 }
 
-async function setProjects(args: { workspaceFolder: vscode.WorkspaceFolder }) {
+export async function discoverProjectsInWorkspace(args: {
+	workspaceFolder: vscode.WorkspaceFolder
+}): Promise<Array<{ projectPath: string }>> {
 	try {
 		const workspacePath = fg.convertPathToPattern(args.workspaceFolder.uri.fsPath) // Normalize path
-		const projectsList = (
+		return (
 			await fg.async(`${workspacePath}/**/*.inlang`, {
 				onlyDirectories: true,
 				ignore: ["**/node_modules/**"],
 				absolute: true, // Ensures paths are absolute and properly formatted
 				cwd: workspacePath, // Makes it platform-agnostic
+				suppressErrors: true,
 			})
 		).map((project) => ({
 			projectPath: project,
 		}))
-
-		setState({
-			...state(),
-			projectsInWorkspace: projectsList,
-		})
 	} catch (error) {
 		handleError(error)
+		return []
 	}
+}
+
+async function setProjects(args: { workspaceFolder: vscode.WorkspaceFolder }) {
+	setProjectsInWorkspace(await discoverProjectsInWorkspace(args))
 }
 
 export async function saveProject() {

--- a/src/utilities/state.ts
+++ b/src/utilities/state.ts
@@ -26,6 +26,21 @@ export function setState(state: State) {
 }
 
 /**
+ * Updates the list of projects discovered in the workspace.
+ *
+ * Project discovery runs before a project is loaded, so this can be the first
+ * state written during extension startup.
+ */
+export function setProjectsInWorkspace(projectsInWorkspace: State["projectsInWorkspace"]) {
+	_state = {
+		..._state,
+		projectsInWorkspace,
+	}
+
+	if (_state.project) proxyPluginGetMethod(_state.project)
+}
+
+/**
  * Returns the current state.
  *
  * The state is a function because importing a variable


### PR DESCRIPTION
## Summary

- Make workspace project discovery best-effort by suppressing unreadable-directory traversal errors from `fast-glob`.
- Initialize the discovered project list through a dedicated state helper so startup can continue to the Getting Started view when discovery fails.
- Add regression coverage for discovery errors and activation fallback behavior.

## Why

A restricted folder in the workspace could cause project discovery to throw `EACCES`, leaving extension state uninitialized and preventing the Getting Started view from loading.

Closes #179

## Validation

- `pnpm vitest run src/main.test.ts`
- `pnpm exec tsc --noEmit`
- `pnpm test`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Startup and discovery-path changes only; behavior is more defensive with tests and a patch changeset.
> 
> **Overview**
> Workspace project discovery no longer aborts activation when some folders are unreadable. **`fast-glob`** now runs with **`suppressErrors: true`**, and discovery is split into **`discoverProjectsInWorkspace`**, which reports errors via **`handleError`** and returns an empty list instead of leaving startup without a project list.
> 
> Startup state is updated through a new **`setProjectsInWorkspace`** helper so the discovered list can be written before a full inlang project is loaded, allowing **`main`** to still open the **Getting Started** view when discovery finds nothing or fails (e.g. **`EACCES`**). Regression tests cover glob options, empty results on failure, and activation fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9437fe05ebc832936202072247c1ff4ed71298f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->