### PR TITLE
[codex] Update inlang editor component for RTL locale layout

### DIFF
--- a/.changeset/fix-rtl-editor-actions.md
+++ b/.changeset/fix-rtl-editor-actions.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Update the inlang editor component so RTL locales keep editor actions aligned while preserving RTL text direction.

--- a/package.json
+++ b/package.json
@@ -276,9 +276,9 @@
 	},
 	"dependencies": {
 		"@eliaspourquoi/sqlite-node-wasm": "3.46.0-build2",
-		"@inlang/editor-component": "10.0.0",
+		"@inlang/editor-component": "10.0.3",
 		"@inlang/recommend-sherlock": "0.2.1",
-		"@inlang/sdk": "2.10.0",
+		"@inlang/sdk": "2.10.2",
 		"@inlang/settings-component": "5.0.0",
 		"@vitest/coverage-v8": "^3.2.4",
 		"comlink": "^4.4.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,17 +12,17 @@ importers:
         specifier: 3.46.0-build2
         version: 3.46.0-build2
       '@inlang/editor-component':
-        specifier: 10.0.0
-        version: 10.0.0(@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
+        specifier: 10.0.3
+        version: 10.0.3(@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
       '@inlang/recommend-sherlock':
         specifier: 0.2.1
         version: 0.2.1
       '@inlang/sdk':
-        specifier: 2.10.0
-        version: 2.10.0(babel-plugin-macros@3.1.0)
+        specifier: 2.10.2
+        version: 2.10.2(babel-plugin-macros@3.1.0)
       '@inlang/settings-component':
         specifier: 5.0.0
-        version: 5.0.0(@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
+        version: 5.0.0(@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
       '@vitest/coverage-v8':
         specifier: ^3.2.4
         version: 3.2.4(vitest@3.2.4(@types/debug@4.1.12)(@types/node@20.19.27)(jsdom@27.4.0)(lightningcss@1.30.2)(terser@5.44.1))
@@ -157,11 +157,11 @@ importers:
   src/utilities/editor/sherlock-editor-app:
     dependencies:
       '@inlang/editor-component':
-        specifier: 10.0.0
-        version: 10.0.0(@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
+        specifier: 10.0.3
+        version: 10.0.3(@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0))(@types/react@19.2.7)
       '@inlang/sdk':
-        specifier: 2.10.0
-        version: 2.10.0(babel-plugin-macros@3.1.0)
+        specifier: 2.10.2
+        version: 2.10.2(babel-plugin-macros@3.1.0)
       '@lit/react':
         specifier: ^1.0.5
         version: 1.0.8(@types/react@19.2.7)
@@ -868,16 +868,16 @@ packages:
     resolution: {integrity: sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==}
     engines: {node: '>=18.18'}
 
-  '@inlang/editor-component@10.0.0':
-    resolution: {integrity: sha512-C0G9xQ0Ft413aQekOkstwWltirlTczSvNWpTHmKpGfAy+KjcKCEKRuOnzYmUlwOOvkYyEeIAybhANgvYaDCMcA==}
+  '@inlang/editor-component@10.0.3':
+    resolution: {integrity: sha512-27M+mqL9fuwUNR+0Cl5tK7nj++83EqoxyPYeIH+K1A9vmxw1TvvuZF02HVCtRSBT3sBPMWJ7JlRkLbYF0k5aEQ==}
     peerDependencies:
-      '@inlang/sdk': 2.10.0
+      '@inlang/sdk': 2.10.2
 
   '@inlang/recommend-sherlock@0.2.1':
     resolution: {integrity: sha512-ckv8HvHy/iTqaVAEKrr+gnl+p3XFNwe5D2+6w6wJk2ORV2XkcRkKOJ/XsTUJbPSiyi4PI+p+T3bqbmNx/rDUlg==}
 
-  '@inlang/sdk@2.10.0':
-    resolution: {integrity: sha512-xLVRHAI9Jw6L/NrlK6s1mXCvbFwzk5INEL4i3By4jW9yjIMchJ+JGSw4WgFpiLlcoBuR/qIMmSn6te/Jozuybg==}
+  '@inlang/sdk@2.10.2':
+    resolution: {integrity: sha512-O1ki72SNK6LPagaGrvlioBb1mWKvump7cO7P85hfGZjdFTmDdn3icI0A6MvaBsB3P9KQHAjzyubnN1OslGufTw==}
     engines: {node: '>=20.0.0'}
 
   '@inlang/settings-component@5.0.0':
@@ -1990,6 +1990,7 @@ packages:
   basic-ftp@5.1.0:
     resolution: {integrity: sha512-RkaJzeJKDbaDWTIPiJwubyljaEPwpVWkm9Rt5h9Nd6h7tEXTJ3VB4qxdZBioV7JO5yLUaOKwz7vDOzlncUsegw==}
     engines: {node: '>=10.0.0'}
+    deprecated: Security vulnerability fixed in 5.2.1, please upgrade
 
   better-path-resolve@1.0.0:
     resolution: {integrity: sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g==}
@@ -3032,29 +3033,31 @@ packages:
 
   glob@10.5.0:
     resolution: {integrity: sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.1.0:
     resolution: {integrity: sha512-vuNwKSaKiqm7g0THUBu2x7ckSs3XJLXE+2ssL7/MfTGPLLcrJQ/4Uq1CjPTtO5cCIiRxqvN6Twy1qOwhL0Xjcw==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.1.2:
     resolution: {integrity: sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.1.7:
     resolution: {integrity: sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   globals@14.0.0:
     resolution: {integrity: sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==}
@@ -4284,6 +4287,7 @@ packages:
   prebuild-install@7.1.3:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
+    deprecated: No longer maintained. Please contact the author of the relevant native addon; alternatives are available.
     hasBin: true
 
   prelude-ls@1.2.1:
@@ -6085,9 +6089,9 @@ snapshots:
 
   '@humanwhocodes/retry@0.4.3': {}
 
-  '@inlang/editor-component@10.0.0(@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0))(@types/react@19.2.7)':
+  '@inlang/editor-component@10.0.3(@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0))(@types/react@19.2.7)':
     dependencies:
-      '@inlang/sdk': 2.10.0(babel-plugin-macros@3.1.0)
+      '@inlang/sdk': 2.10.2(babel-plugin-macros@3.1.0)
       '@lexical/plain-text': 0.16.1
       '@lexical/utils': 0.16.1
       '@lit/task': 1.0.3
@@ -6103,7 +6107,7 @@ snapshots:
     dependencies:
       comment-json: 4.5.1
 
-  '@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0)':
+  '@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0)':
     dependencies:
       '@lix-js/sdk': 0.4.10(babel-plugin-macros@3.1.0)
       '@sinclair/typebox': 0.31.28
@@ -6113,9 +6117,9 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@inlang/settings-component@5.0.0(@inlang/sdk@2.10.0(babel-plugin-macros@3.1.0))(@types/react@19.2.7)':
+  '@inlang/settings-component@5.0.0(@inlang/sdk@2.10.2(babel-plugin-macros@3.1.0))(@types/react@19.2.7)':
     dependencies:
-      '@inlang/sdk': 2.10.0(babel-plugin-macros@3.1.0)
+      '@inlang/sdk': 2.10.2(babel-plugin-macros@3.1.0)
       '@lit/task': 1.0.3
       '@shoelace-style/shoelace': 2.14.0(@types/react@19.2.7)
       '@sinclair/typebox': 0.31.28

--- a/src/utilities/editor/sherlock-editor-app/package.json
+++ b/src/utilities/editor/sherlock-editor-app/package.json
@@ -10,8 +10,8 @@
 		"preview": "vite preview"
 	},
 	"dependencies": {
-		"@inlang/editor-component": "10.0.0",
-		"@inlang/sdk": "2.10.0",
+		"@inlang/editor-component": "10.0.3",
+		"@inlang/sdk": "2.10.2",
 		"@lit/react": "^1.0.5",
 		"clsx": "^2.1.1",
 		"jotai": "^2.11.1",


### PR DESCRIPTION
## Summary

- Update `@inlang/editor-component` to `10.0.3` in Sherlock and the embedded editor app.
- Keep `@inlang/sdk` on the matching `2.10.2` peer version.
- Add a patch changeset for `vs-code-extension`.

## Why

`@inlang/editor-component@10.0.3` includes the RTL layout fix that keeps editor row actions aligned while preserving automatic text direction in pattern editors and selector match inputs.

## Validation

- `pnpm run build`
- `pnpm test`
- Targeted Chromium smoke test verified the installed component keeps RTL row structure stable while Arabic pattern and match inputs compute RTL direction.

Closes https://github.com/opral/sherlock/issues/191

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> No application code changes—only version pins, lockfile, and a changeset; risk is limited to regression in the embedded inlang editor UI.
> 
> **Overview**
> Bumps **`@inlang/editor-component`** from `10.0.0` to **`10.0.3`** and **`@inlang/sdk`** from `2.10.0` to **`2.10.2`** in the root extension and **`sherlock-editor-app`**, with matching **`pnpm-lock.yaml`** updates.
> 
> Adds a **patch changeset** for `vs-code-extension` so the release notes call out the upstream RTL fix: editor row actions stay aligned for RTL locales while pattern editors and selector match inputs keep automatic RTL text direction.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b3e62568810405da6d9db387b98486dfc8ec8dad. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->