### PR TITLE
Fix preview locale selection and project settings

### DIFF
--- a/.changeset/fix-preview-language-selection.md
+++ b/.changeset/fix-preview-language-selection.md
@@ -2,4 +2,4 @@
 "vs-code-extension": patch
 ---
 
-Use the selected preview locale for inline annotations and highlight it in the locale picker.
+Respect the selected preview locale in inline annotations and the locale picker, and include the project settings dependencies in production builds.

--- a/.changeset/fix-preview-language-selection.md
+++ b/.changeset/fix-preview-language-selection.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Use the selected preview locale for inline annotations and highlight it in the locale picker.

--- a/build.js
+++ b/build.js
@@ -68,13 +68,13 @@ if (isDev) {
 
 const ctx = await context(buildOptions)
 
+await copyDependencies()
+await copyDirectories()
+
 if (isDev) {
-	await copyDependencies()
-	await copyDirectories()
 	await ctx.watch()
 	console.info("👀 watching for changes...")
 } else {
-	await copyDirectories()
 	await ctx.rebuild()
 	console.info("✅ build complete")
 	await ctx.dispose()

--- a/src/commands/previewLocaleCommand.test.ts
+++ b/src/commands/previewLocaleCommand.test.ts
@@ -4,12 +4,14 @@ import * as settings from "../utilities/settings/index.js"
 import { previewLocaleCommand } from "./previewLocaleCommand.js"
 import { CONFIGURATION } from "../configuration.js"
 import { state } from "../utilities/state.js"
+import { getPreviewLocale } from "../utilities/locale/getPreviewLocale.js"
 
 vi.mock("vscode", () => ({
-	window: { showQuickPick: vi.fn() },
+	window: { createQuickPick: vi.fn() },
 	commands: { registerCommand: vi.fn() },
 }))
 vi.mock("../utilities/settings/index.js", () => ({ updateSetting: vi.fn() }))
+vi.mock("../utilities/locale/getPreviewLocale.js", () => ({ getPreviewLocale: vi.fn() }))
 vi.mock("../utilities/settings/statusBar.js", () => ({
 	showStatusBar: vi.fn(),
 }))
@@ -27,9 +29,52 @@ vi.mock("../configuration.js", () => ({
 	},
 }))
 
+const createQuickPickMock = (selectedLocale?: string) => {
+	let acceptListener: (() => void) | undefined
+	let hideListener: (() => void) | undefined
+
+	const quickPick = {
+		activeItems: [] as { label: string }[],
+		dispose: vi.fn(),
+		hide: vi.fn(() => hideListener?.()),
+		items: [] as { label: string }[],
+		onDidAccept: vi.fn((listener: () => void) => {
+			acceptListener = listener
+		}),
+		onDidHide: vi.fn((listener: () => void) => {
+			hideListener = listener
+		}),
+		placeholder: "",
+		selectedItems: [] as { label: string }[],
+		show: vi.fn(() => {
+			if (!selectedLocale) {
+				hideListener?.()
+				return
+			}
+
+			quickPick.selectedItems = [{ label: selectedLocale }]
+			acceptListener?.()
+		}),
+	}
+
+	return quickPick
+}
+
 describe("previewLocaleCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		vi.mocked(getPreviewLocale).mockResolvedValue("en")
+		vi.mocked(state).mockReturnValue({
+			project: {
+				// @ts-expect-error
+				settings: {
+					get: vi.fn().mockResolvedValue({
+						baseLocale: "ckb",
+						locales: ["ckb", "en", "fr"],
+					}),
+				},
+			},
+		})
 	})
 
 	it("should register the command", () => {
@@ -39,26 +84,15 @@ describe("previewLocaleCommand", () => {
 	})
 
 	it("should show language tags and update setting if a tag is selected", async () => {
-		vi.mocked(state).mockReturnValue({
-			project: {
-				// @ts-expect-error
-				settings: {
-					get: vi.fn().mockResolvedValue({
-						baseLocale: "en",
-						locales: ["en", "es", "fr"],
-					}),
-				},
-			},
-		})
-		// @ts-expect-error
-		vi.mocked(vscode.window.showQuickPick).mockResolvedValue("en")
+		const quickPick = createQuickPickMock("fr")
+		vi.mocked(vscode.window.createQuickPick).mockReturnValue(quickPick as never)
 
 		await previewLocaleCommand.callback()
 
-		expect(vscode.window.showQuickPick).toHaveBeenCalledWith(["en", "es", "fr"], {
-			placeHolder: "Select a language",
-		})
-		expect(settings.updateSetting).toHaveBeenCalledWith("previewLanguageTag", "en")
+		expect(quickPick.items).toEqual([{ label: "ckb" }, { label: "en" }, { label: "fr" }])
+		expect(quickPick.activeItems).toEqual([{ label: "en" }])
+		expect(quickPick.placeholder).toBe("Select a language")
+		expect(settings.updateSetting).toHaveBeenCalledWith("previewLanguageTag", "fr")
 		expect(CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire).toHaveBeenCalledTimes(1)
 		expect(CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire).toHaveBeenCalledTimes(1)
 		expect(CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire).toHaveBeenCalledTimes(1)
@@ -66,7 +100,8 @@ describe("previewLocaleCommand", () => {
 	})
 
 	it("should not update setting if no tag is selected", async () => {
-		vi.mocked(vscode.window.showQuickPick).mockResolvedValue(undefined)
+		const quickPick = createQuickPickMock()
+		vi.mocked(vscode.window.createQuickPick).mockReturnValue(quickPick as never)
 
 		await previewLocaleCommand.callback()
 

--- a/src/commands/previewLocaleCommand.ts
+++ b/src/commands/previewLocaleCommand.ts
@@ -2,6 +2,28 @@ import * as vscode from "vscode"
 import { updateSetting } from "../utilities/settings/index.js"
 import { state } from "../utilities/state.js"
 import { CONFIGURATION } from "../configuration.js"
+import { getPreviewLocale } from "../utilities/locale/getPreviewLocale.js"
+
+const showPreviewLocalePicker = async (locales: string[]): Promise<string | undefined> => {
+	const previewLocale = await getPreviewLocale()
+	const quickPick = vscode.window.createQuickPick()
+	quickPick.placeholder = "Select a language"
+	quickPick.items = locales.map((locale) => ({ label: locale }))
+	quickPick.activeItems = quickPick.items.filter((item) => item.label === previewLocale)
+
+	try {
+		return await new Promise((resolve) => {
+			quickPick.onDidAccept(() => {
+				resolve(quickPick.selectedItems[0]?.label)
+				quickPick.hide()
+			})
+			quickPick.onDidHide(() => resolve(undefined))
+			quickPick.show()
+		})
+	} finally {
+		quickPick.dispose()
+	}
+}
 
 export const previewLocaleCommand = {
 	command: "sherlock.previewLanguageTag",
@@ -9,9 +31,7 @@ export const previewLocaleCommand = {
 	register: vscode.commands.registerCommand,
 	callback: async () => {
 		const settings = await state().project?.settings.get()
-		const selectedLocale = await vscode.window.showQuickPick(settings.locales, {
-			placeHolder: "Select a language",
-		})
+		const selectedLocale = await showPreviewLocalePicker(settings.locales)
 
 		if (!selectedLocale) {
 			return

--- a/src/decorations/messagePreview.test.ts
+++ b/src/decorations/messagePreview.test.ts
@@ -1,0 +1,141 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { messagePreview } from "./messagePreview.js"
+
+const mocks = vi.hoisted(() => ({
+	setDecorations: vi.fn(),
+	getPreviewLocale: vi.fn(),
+	getSetting: vi.fn(),
+	getExtensionApi: vi.fn(),
+	getSelectedBundleByBundleIdOrAlias: vi.fn(),
+}))
+
+vi.mock("vscode", () => ({
+	Position: class Position {
+		constructor(
+			public line: number,
+			public character: number
+		) {}
+	},
+	Range: class Range {
+		constructor(
+			public start: unknown,
+			public end: unknown
+		) {}
+	},
+	ThemeColor: class ThemeColor {
+		constructor(public id: string) {}
+	},
+	window: {
+		activeTextEditor: {
+			document: {
+				fileName: "/workspace/src/page.ts",
+				getText: vi.fn(() => "m.root_title()"),
+			},
+			setDecorations: mocks.setDecorations,
+		},
+		createTextEditorDecorationType: vi.fn(() => ({ key: "preview" })),
+		onDidChangeActiveTextEditor: vi.fn(),
+	},
+	workspace: {
+		getConfiguration: vi.fn(() => ({ get: vi.fn(() => true) })),
+		onDidChangeConfiguration: vi.fn(),
+		onDidChangeTextDocument: vi.fn(),
+	},
+}))
+
+vi.mock("../utilities/state.js", () => ({
+	state: () => ({
+		project: {
+			settings: {
+				get: vi.fn(async () => ({ baseLocale: "ckb", locales: ["ckb", "en"] })),
+			},
+		},
+	}),
+}))
+
+vi.mock("./contextTooltip.js", () => ({
+	contextTooltip: vi.fn(async () => undefined),
+}))
+
+vi.mock("../utilities/locale/getPreviewLocale.js", () => ({
+	getPreviewLocale: mocks.getPreviewLocale,
+}))
+
+vi.mock("../utilities/settings/index.js", () => ({
+	getSetting: mocks.getSetting,
+}))
+
+vi.mock("../utilities/helper.js", () => ({
+	getExtensionApi: mocks.getExtensionApi,
+	getSelectedBundleByBundleIdOrAlias: mocks.getSelectedBundleByBundleIdOrAlias,
+}))
+
+vi.mock("../configuration.js", () => ({
+	CONFIGURATION: {
+		EVENTS: {
+			ON_DID_CREATE_MESSAGE: { event: vi.fn() },
+			ON_DID_EDIT_MESSAGE: { event: vi.fn() },
+			ON_DID_EXTRACT_MESSAGE: { event: vi.fn() },
+			ON_DID_PREVIEW_LOCALE_CHANGE: { event: vi.fn() },
+		},
+	},
+}))
+
+describe("messagePreview", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.getPreviewLocale.mockResolvedValue("en")
+		mocks.getSetting.mockResolvedValue("transparent")
+		mocks.getExtensionApi.mockResolvedValue({
+			messageReferenceMatchers: [
+				vi.fn(async () => [
+					{
+						bundleId: "root_title",
+						position: {
+							start: { line: 1, character: 1 },
+							end: { line: 1, character: 15 },
+						},
+					},
+				]),
+			],
+		})
+		mocks.getSelectedBundleByBundleIdOrAlias.mockResolvedValue({
+			messages: [
+				{
+					locale: "ckb",
+					variants: [
+						{
+							messageId: "root_title_ckb",
+							matches: [{ type: "catchall-match" }],
+							pattern: [{ type: "text", value: "سەردێڕ" }],
+						},
+					],
+				},
+				{
+					locale: "en",
+					variants: [
+						{
+							messageId: "root_title_en",
+							matches: [{ type: "catchall-match" }],
+							pattern: [{ type: "text", value: "Root title" }],
+						},
+					],
+				},
+			],
+		})
+	})
+
+	it("renders the message for the selected preview locale", async () => {
+		await messagePreview({ context: { subscriptions: [] } as never })
+
+		await vi.waitFor(() => {
+			expect(mocks.setDecorations).toHaveBeenCalledWith(expect.anything(), [
+				expect.objectContaining({
+					renderOptions: expect.objectContaining({
+						after: expect.objectContaining({ contentText: "Root title" }),
+					}),
+				}),
+			])
+		})
+	})
+})

--- a/src/decorations/messagePreview.ts
+++ b/src/decorations/messagePreview.ts
@@ -76,15 +76,15 @@ export async function messagePreview(args: { context: vscode.ExtensionContext })
 					// Retrieve the bundle and messages
 					const _bundle = await getSelectedBundleByBundleIdOrAlias(bundle.bundleId)
 
+					const previewLocale = await getPreviewLocale()
+					const translationLocale = previewLocale.length ? previewLocale : baseLocale
+
 					// Get the message from the bundle
-					const message = _bundle?.messages.find((m) => m.locale === baseLocale)
+					const message = _bundle?.messages.find((m) => m.locale === translationLocale)
 
 					const variant =
 						message?.variants.find((v) => v.matches.some((m) => m.type === "catchall-match")) ||
 						message?.variants[0]
-
-					const previewLocale = await getPreviewLocale()
-					const translationLocale = previewLocale.length ? previewLocale : baseLocale
 
 					const translationString = variant
 						? getStringFromPattern({

--- a/src/main.ts
+++ b/src/main.ts
@@ -279,7 +279,6 @@ async function restoreExplicitDottedMessageKeys(snapshots: DottedMessageKeySnaps
 			new Set(Object.keys(json).filter((key) => key !== "$schema"))
 		)
 	}
-
 }
 
 async function removeMessagesDeletedFromJsonFiles() {

--- a/src/package.json.test.ts
+++ b/src/package.json.test.ts
@@ -1,8 +1,18 @@
-import { it, expect } from "vitest"
+import { existsSync } from "node:fs"
+import { describe, expect, it } from "vitest"
 import packageJson from "../package.json"
 
 it("should have matching engine and dependency versions", () => {
 	expect(packageJson.engines.vscode.replace(/^\^/, "")).toBe(
 		packageJson.devDependencies["@types/vscode"]
+	)
+})
+
+describe("production build", () => {
+	it.each(["lit-html.js", "settings-component.js"])(
+		"includes the %s settings dependency",
+		(fileName) => {
+			expect(existsSync(new URL(`../assets/${fileName}`, import.meta.url))).toBe(true)
+		}
 	)
 })

--- a/src/utilities/fs/experimental/directMessageHandler.ts
+++ b/src/utilities/fs/experimental/directMessageHandler.ts
@@ -177,9 +177,9 @@ export async function setupDirectMessageWatcher(args: {
 				return
 			}
 
-				// Check if we're in an event loop
-				if (isInEventLoop) {
-					console.log("Detected potential event loop, breaking the cycle")
+			// Check if we're in an event loop
+			if (isInEventLoop) {
+				console.log("Detected potential event loop, breaking the cycle")
 				return
 			}
 


### PR DESCRIPTION
## What changed

- use the selected preview locale for inline annotations
- highlight the current preview locale in the language picker
- include the project settings webview dependencies in production builds
- apply the repository formatter to the touched source

## Why

Inline annotations always selected the base-locale message, and the language picker could not initialize its highlighted item with the previous API. Production builds also skipped copying the scripts required by the project settings webview.

## Validation

- `pnpm format`
- `pnpm build`
- `pnpm test` — 156 passed, 3 skipped
- `pnpm test:e2e` — 6 spec files passed
- `pnpm package`
- installed the VSIX
- verified English annotations, the selected picker item, and the project settings view in VS Code

Closes #184