### PR TITLE
Separate project sessions from extension activation

### DIFF
--- a/src/commands/createMessage.test.ts
+++ b/src/commands/createMessage.test.ts
@@ -9,6 +9,11 @@ import { humanId, upsertBundleNested } from "@inlang/sdk"
 import { state } from "../utilities/state.js"
 import { v4 as uuidv4 } from "uuid"
 
+const runtimeLease = vi.hoisted(() => ({
+	runTask: vi.fn(),
+	isCurrent: vi.fn(),
+}))
+
 vi.mock("vscode", () => ({
 	window: {
 		showInputBox: vi.fn(),
@@ -51,6 +56,22 @@ vi.mock("../utilities/state", () => ({
 	state: vi.fn(),
 }))
 
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						path: "/workspace/project.inlang",
+						isCurrent: runtimeLease.isCurrent,
+						runTask: runtimeLease.runTask,
+					}
+				: undefined
+		},
+	}),
+}))
+
 vi.mock("uuid", () => ({
 	v4: vi.fn().mockReturnValue("mocked-uuid-123"),
 }))
@@ -58,6 +79,11 @@ vi.mock("uuid", () => ({
 describe("createMessageCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		runtimeLease.isCurrent.mockReset().mockReturnValue(true)
+		runtimeLease.runTask.mockReset().mockImplementation(async (task: () => Promise<unknown>) => ({
+			status: "completed",
+			value: await task(),
+		}))
 	})
 
 	it("should return if message content input is cancelled", async () => {
@@ -157,6 +183,30 @@ describe("createMessageCommand", () => {
 		expect(CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire).toHaveBeenCalled()
 		expect(capture).toHaveBeenCalled()
 		expect(msg).toHaveBeenCalledWith("Message created.")
+	})
+
+	it("does not create a message after its project lease becomes stale", async () => {
+		vi.mocked(state).mockReturnValue({
+			project: {
+				settings: { get: vi.fn().mockResolvedValue({ baseLocale: "en" }) },
+			},
+		} as any)
+		vi.mocked(getSetting).mockResolvedValueOnce(false)
+		vi.mocked(window.showInputBox)
+			.mockResolvedValueOnce("Some message content")
+			.mockResolvedValueOnce("messageId123")
+		runtimeLease.runTask
+			.mockImplementationOnce(async (task: () => Promise<unknown>) => ({
+				status: "completed",
+				value: await task(),
+			}))
+			.mockResolvedValueOnce({ status: "inactive" })
+
+		await createMessageCommand.callback()
+
+		expect(upsertBundleNested).not.toHaveBeenCalled()
+		expect(CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire).not.toHaveBeenCalled()
+		expect(msg).toHaveBeenCalledWith("The active project changed before the message was created.")
 	})
 
 	it("should use humanId as default messageId if autoHumanId is true", async () => {

--- a/src/commands/createMessage.ts
+++ b/src/commands/createMessage.ts
@@ -1,11 +1,11 @@
-import { state } from "../utilities/state.js"
 import { msg } from "../utilities/messages/msg.js"
 import { commands, window } from "vscode"
 import { capture } from "../services/telemetry/index.js"
-import { humanId, upsertBundleNested, type NewBundleNested } from "@inlang/sdk"
+import { humanId, upsertBundleNested, type InlangProject, type NewBundleNested } from "@inlang/sdk"
 import { CONFIGURATION } from "../configuration.js"
 import { getSetting } from "../utilities/settings/index.js"
 import { v4 as uuidv4 } from "uuid"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 /**
  * Helps the user to create messages by prompting for the message content.
@@ -15,7 +15,13 @@ export const createMessageCommand = {
 	title: "Sherlock: Create Message",
 	register: commands.registerCommand,
 	callback: async function () {
-		const baseLocale = (await state().project.settings.get()).baseLocale
+		const lease = getProjectRuntime<InlangProject>().activeProject()
+		if (!lease) return msg("No active project.")
+		const baseLocaleResult = await lease.runTask(
+			async () => (await lease.project.settings.get()).baseLocale
+		)
+		if (baseLocaleResult.status !== "completed") return
+		const baseLocale = baseLocaleResult.value
 
 		const messageValue = await window.showInputBox({
 			title: "Enter the message content:",
@@ -67,7 +73,13 @@ export const createMessageCommand = {
 		}
 
 		try {
-			await upsertBundleNested(state().project?.db, bundle)
+			const created = await lease.runTask(async () => {
+				await upsertBundleNested(lease.project.db, bundle)
+				return true
+			})
+			if (created.status !== "completed") {
+				return msg("The active project changed before the message was created.")
+			}
 
 			// Emit event to notify that a message was created
 			CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire()

--- a/src/commands/editMessage.test.ts
+++ b/src/commands/editMessage.test.ts
@@ -5,7 +5,12 @@ import { state } from "../utilities/state.js"
 import { msg } from "../utilities/messages/msg.js"
 import { CONFIGURATION } from "../configuration.js"
 import { getPatternFromString, getStringFromPattern } from "../utilities/messages/query.js"
-import { getSelectedBundleByBundleIdOrAlias } from "../utilities/helper.js" // Import the function to be mocked
+import { selectBundleById } from "../utilities/project/selectBundleById.js"
+
+const runtimeLease = vi.hoisted(() => ({
+	runTask: vi.fn(),
+	isCurrent: vi.fn(),
+}))
 
 vi.mock("vscode", () => ({
 	commands: {
@@ -38,14 +43,36 @@ vi.mock("../utilities/messages/query.js", () => ({
 	getStringFromPattern: vi.fn(),
 }))
 
-// Mock the helper module
-vi.mock("../utilities/helper.js", () => ({
-	getSelectedBundleByBundleIdOrAlias: vi.fn(),
+vi.mock("../utilities/project/selectBundleById.js", () => ({
+	selectBundleById: vi.fn(),
+}))
+
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						path: "/workspace/project.inlang",
+						isCurrent: runtimeLease.isCurrent,
+						runTask: runtimeLease.runTask,
+					}
+				: undefined
+		},
+	}),
 }))
 
 describe("editMessageCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		vi.mocked(selectBundleById).mockReset()
+		vi.mocked(window.showInputBox).mockReset()
+		runtimeLease.isCurrent.mockReset().mockReturnValue(true)
+		runtimeLease.runTask.mockReset().mockImplementation(async (task: () => Promise<unknown>) => ({
+			status: "completed",
+			value: await task(),
+		}))
 	})
 
 	it("should show a message if the bundle is not found", async () => {
@@ -58,7 +85,7 @@ describe("editMessageCommand", () => {
 			},
 		})
 
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValueOnce(undefined)
+		vi.mocked(selectBundleById).mockResolvedValueOnce(undefined)
 
 		await editMessageCommand.callback({ bundleId: "testBundle", locale: "en" })
 
@@ -77,7 +104,7 @@ describe("editMessageCommand", () => {
 			},
 		})
 
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValueOnce(mockBundle)
+		vi.mocked(selectBundleById).mockResolvedValueOnce(mockBundle)
 
 		await editMessageCommand.callback({ bundleId: "testBundle", locale: "en" })
 
@@ -108,7 +135,7 @@ describe("editMessageCommand", () => {
 		})
 
 		// @ts-expect-error
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValueOnce(mockBundle)
+		vi.mocked(selectBundleById).mockResolvedValueOnce(mockBundle)
 
 		await editMessageCommand.callback({ bundleId: "testBundle", locale: "en" })
 
@@ -151,14 +178,50 @@ describe("editMessageCommand", () => {
 		})
 
 		// @ts-expect-error
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValueOnce(mockBundle)
+		vi.mocked(selectBundleById).mockResolvedValueOnce(mockBundle)
 
 		vi.mocked(window.showInputBox).mockResolvedValueOnce(undefined)
 
 		await editMessageCommand.callback({ bundleId: "testBundle", locale: "en" })
 
-		expect(state().project.db.transaction().execute).not.toHaveBeenCalled()
+		expect(state().project?.db.transaction().execute).not.toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire).not.toHaveBeenCalled()
+	})
+
+	it("does not update a message after its project lease becomes stale", async () => {
+		const execute = vi.fn()
+		vi.mocked(state).mockReturnValue({
+			project: { db: { transaction: vi.fn(() => ({ execute })) } },
+		} as any)
+		vi.mocked(selectBundleById).mockResolvedValueOnce({
+			id: "testBundle",
+			declarations: [],
+			messages: [
+				{
+					id: "testMessage",
+					bundleId: "testBundle",
+					locale: "en",
+					selectors: [],
+					variants: [{ id: "testVariant", messageId: "testMessage", matches: [], pattern: [] }],
+				},
+			],
+		} as any)
+		vi.mocked(getStringFromPattern).mockReturnValue("Current content")
+		vi.mocked(getPatternFromString).mockReturnValue([])
+		vi.mocked(window.showInputBox).mockResolvedValueOnce("Updated content")
+		runtimeLease.runTask.mockImplementation(async (task: () => Promise<unknown>) =>
+			runtimeLease.runTask.mock.calls.length === 1
+				? { status: "completed", value: await task() }
+				: { status: "inactive" }
+		)
+
+		await editMessageCommand.callback({ bundleId: "testBundle", locale: "en" })
+
+		expect(runtimeLease.runTask).toHaveBeenCalledTimes(2)
+		expect(window.showInputBox).toHaveBeenCalledTimes(1)
+		expect(execute).not.toHaveBeenCalled()
+		expect(CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire).not.toHaveBeenCalled()
+		expect(msg).toHaveBeenCalledWith("The active project changed before the message was updated.")
 	})
 
 	it.todo("should update an existing message and variant", async () => {
@@ -189,7 +252,7 @@ describe("editMessageCommand", () => {
 		}
 
 		// @ts-expect-error
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValue(mockBundle)
+		vi.mocked(selectBundleById).mockResolvedValue(mockBundle)
 
 		const mockTransaction = {
 			execute: vi.fn().mockResolvedValue({}),
@@ -262,7 +325,7 @@ describe("editMessageCommand", () => {
 		})
 
 		// @ts-expect-error
-		vi.mocked(getSelectedBundleByBundleIdOrAlias).mockResolvedValue(mockBundle)
+		vi.mocked(selectBundleById).mockResolvedValue(mockBundle)
 		vi.mocked(window.showInputBox).mockResolvedValue("Updated content")
 
 		await editMessageCommand.callback({

--- a/src/commands/editMessage.ts
+++ b/src/commands/editMessage.ts
@@ -1,17 +1,21 @@
-import { state } from "../utilities/state.js"
 import { msg } from "../utilities/messages/msg.js"
 import { commands, window } from "vscode"
 import { getPatternFromString, getStringFromPattern } from "../utilities/messages/query.js"
 import { CONFIGURATION } from "../configuration.js"
-import { type Bundle } from "@inlang/sdk"
-import { getSelectedBundleByBundleIdOrAlias } from "../utilities/helper.js"
+import { type Bundle, type InlangProject } from "@inlang/sdk"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
+import { selectBundleById } from "../utilities/project/selectBundleById.js"
 
 export const editMessageCommand = {
 	command: "sherlock.editMessage",
 	title: "Sherlock: Edit a Message",
 	register: commands.registerCommand,
 	callback: async function ({ bundleId, locale }: { bundleId: Bundle["id"]; locale: string }) {
-		const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+		const lease = getProjectRuntime<InlangProject>().activeProject()
+		if (!lease) return msg("No active project.")
+		const bundleResult = await lease.runTask(() => selectBundleById(lease.project, bundleId))
+		if (bundleResult.status !== "completed") return
+		const bundle = bundleResult.value
 
 		if (!bundle) {
 			return msg(`Bundle with id ${bundleId} not found.`)
@@ -48,9 +52,8 @@ export const editMessageCommand = {
 		variant.pattern = getPatternFromString({ string: newValue })
 
 		try {
-			await state()
-				.project.db.transaction()
-				.execute(async (trx) => {
+			const updated = await lease.runTask(async () => {
+				await lease.project.db.transaction().execute(async (trx) => {
 					await trx
 						.updateTable("message")
 						.set({
@@ -68,6 +71,11 @@ export const editMessageCommand = {
 						.returningAll()
 						.execute()
 				})
+				return true
+			})
+			if (updated.status !== "completed") {
+				return msg("The active project changed before the message was updated.")
+			}
 
 			CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 

--- a/src/commands/extractMessage.test.ts
+++ b/src/commands/extractMessage.test.ts
@@ -8,6 +8,11 @@ import { state } from "../utilities/state.js"
 import { upsertBundleNested } from "@inlang/sdk"
 import { capture } from "../services/telemetry/index.js"
 
+const runtimeLease = vi.hoisted(() => ({
+	runTask: vi.fn(),
+	isCurrent: vi.fn(),
+}))
+
 // Mocking the necessary modules
 vi.mock("../utilities/state", () => ({
 	state: vi.fn(),
@@ -64,6 +69,7 @@ vi.mock("@inlang/sdk", () => ({
 	createBundle: vi.fn().mockReturnValue({ id: "generatedId123", alias: "alias123" }),
 	createMessage: vi.fn().mockReturnValue({ id: "messageId123", bundleId: "generatedId123" }),
 	upsertBundleNested: vi.fn(),
+	saveProjectToDirectory: vi.fn(),
 }))
 
 vi.mock("../utilities/messages/isQuoted", () => ({
@@ -75,9 +81,30 @@ vi.mock("../utilities/state.js", () => ({
 	state: vi.fn(),
 }))
 
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						path: "/workspace/project.inlang",
+						isCurrent: runtimeLease.isCurrent,
+						runTask: runtimeLease.runTask,
+					}
+				: undefined
+		},
+	}),
+}))
+
 describe("extractMessageCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		runtimeLease.isCurrent.mockReset().mockReturnValue(true)
+		runtimeLease.runTask.mockReset().mockImplementation(async (task: () => Promise<unknown>) => ({
+			status: "completed",
+			value: await task(),
+		}))
 	})
 
 	it("should show warning if ideExtension is not configured", async () => {
@@ -502,6 +529,58 @@ describe("extractMessageCommand", () => {
 		expect(mockTextEditor.edit).toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire).toHaveBeenCalled()
 		expect(msg).toHaveBeenCalledWith("Message extracted.")
+	})
+
+	it("does not edit a document after its project lease becomes stale", async () => {
+		vi.mocked(state).mockReturnValue({
+			project: {
+				plugins: {
+					get: async () => [
+						{
+							key: "plugin1",
+							meta: {
+								"app.inlang.ideExtension": {
+									extractMessageOptions: [
+										{
+											callback: vi.fn(() => ({
+												bundleId: "generatedId123",
+												messageReplacement: "Replacement Text",
+											})),
+										},
+									],
+								},
+							},
+						},
+					],
+				},
+				settings: { get: async () => ({ baseLocale: "en", locales: ["en"] }) },
+				db: {},
+			},
+		} as any)
+		const mockTextEditor = {
+			selection: {
+				isEmpty: false,
+				start: { line: 1, character: 1 },
+				end: { line: 1, character: 20 },
+			},
+			document: { getText: () => "Some text" },
+			edit: vi.fn(),
+		}
+		vi.mocked(getSetting).mockResolvedValueOnce(true)
+		vi.mocked(window.showInputBox).mockResolvedValueOnce("generatedId123")
+		vi.mocked(window.showQuickPick).mockResolvedValueOnce("Replacement Text" as never)
+		runtimeLease.runTask.mockImplementation(async (task: () => Promise<unknown>) =>
+			runtimeLease.runTask.mock.calls.length === 1
+				? { status: "completed", value: await task() }
+				: { status: "inactive" }
+		)
+
+		await extractMessageCommand.callback(mockTextEditor as any)
+
+		expect(upsertBundleNested).not.toHaveBeenCalled()
+		expect(mockTextEditor.edit).not.toHaveBeenCalled()
+		expect(CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire).not.toHaveBeenCalled()
+		expect(msg).toHaveBeenCalledWith("The active project changed before the message was extracted.")
 	})
 })
 

--- a/src/commands/extractMessage.ts
+++ b/src/commands/extractMessage.ts
@@ -1,4 +1,3 @@
-import { state } from "../utilities/state.js"
 import { msg } from "../utilities/messages/msg.js"
 import { commands, type TextEditor, window } from "vscode"
 import { capture } from "../services/telemetry/index.js"
@@ -9,10 +8,12 @@ import {
 	humanId,
 	upsertBundleNested,
 	type IdeExtensionConfig,
+	type InlangProject,
 	type NewBundleNested,
 } from "@inlang/sdk"
 import { v4 as uuidv4 } from "uuid"
-import { saveProject } from "../main.js"
+import { saveProjectData } from "../main.js"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 /**
  * Helps the user to extract messages from the active text editor.
@@ -25,11 +26,16 @@ export const extractMessageCommand = {
 		// Simulating an error to test the catch block
 		// throw new Error("Forced error for testing");
 
-		const ideExtension = (await state().project.plugins.get()).find(
-			(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
-		)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
-
-		const baseLocale = (await state().project.settings.get()).baseLocale
+		const lease = getProjectRuntime<InlangProject>().activeProject()
+		if (!lease) return msg("No active project.")
+		const projectConfiguration = await lease.runTask(async () => ({
+			ideExtension: (await lease.project.plugins.get()).find(
+				(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
+			)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined,
+			baseLocale: (await lease.project.settings.get()).baseLocale,
+		}))
+		if (projectConfiguration.status !== "completed") return
+		const { ideExtension, baseLocale } = projectConfiguration.value
 
 		if (!ideExtension) {
 			return msg(
@@ -149,15 +155,21 @@ export const extractMessageCommand = {
 		}
 
 		try {
-			await upsertBundleNested(state().project.db, bundle)
+			const extracted = await lease.runTask(async () => {
+				await upsertBundleNested(lease.project.db, bundle)
 
-			await textEditor.edit((editor) => {
-				editor.replace(textEditor.selection, preparedExtractOption)
+				await textEditor.edit((editor) => {
+					editor.replace(textEditor.selection, preparedExtractOption)
+				})
+
+				await saveProjectData(lease.project, lease.path)
+				return true
 			})
+			if (extracted.status !== "completed") {
+				return msg("The active project changed before the message was extracted.")
+			}
 
 			CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire()
-
-			await saveProject()
 
 			capture({
 				event: "IDE-EXTENSION command executed: Extract Message",

--- a/src/commands/openEditorView.test.ts
+++ b/src/commands/openEditorView.test.ts
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { editorView } from "../utilities/editor/editorView.js"
+import { openEditorViewCommand } from "./openEditorView.js"
+
+const lease = vi.hoisted(() => ({
+	own: vi.fn(),
+}))
+
+vi.mock("vscode", () => ({
+	commands: { registerCommand: vi.fn() },
+	extensions: {
+		getExtension: vi.fn(() => ({ extensionUri: { fsPath: "/extension" } })),
+	},
+}))
+
+vi.mock("../utilities/editor/editorView.js", () => ({
+	editorView: vi.fn(),
+}))
+
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({ activeProject: () => lease }),
+}))
+
+vi.mock("../services/telemetry/index.js", () => ({ capture: vi.fn() }))
+
+describe("Open Editor command", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		lease.own.mockReturnValue(true)
+	})
+
+	it("retires the editor without exporting the replaced project", async () => {
+		const editor = {
+			createOrShowPanel: vi.fn(async () => undefined),
+			dispose: vi.fn(async () => undefined),
+		}
+		vi.mocked(editorView).mockReturnValue(editor as never)
+
+		await openEditorViewCommand.callback({ bundleId: "welcome" })
+
+		const ownedResource = lease.own.mock.calls[0]?.[0]
+		await ownedResource.dispose()
+
+		expect(editor.dispose).toHaveBeenCalledWith()
+	})
+
+	it("exports a focused editor when the extension shuts down", async () => {
+		const editor = {
+			createOrShowPanel: vi.fn(async () => undefined),
+			dispose: vi.fn(async () => undefined),
+		}
+		vi.mocked(editorView).mockReturnValue(editor as never)
+
+		await openEditorViewCommand.callback({ bundleId: "welcome" })
+
+		const ownedResource = lease.own.mock.calls[0]?.[0]
+		await ownedResource.dispose("shutdown")
+
+		expect(editor.dispose).toHaveBeenCalledWith({ persist: true })
+	})
+})

--- a/src/commands/openEditorView.ts
+++ b/src/commands/openEditorView.ts
@@ -2,20 +2,27 @@ import { commands } from "vscode"
 import { capture } from "../services/telemetry/index.js"
 import { editorView } from "../utilities/editor/editorView.js"
 import * as vscode from "vscode"
+import type { InlangProject } from "@inlang/sdk"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 export const openEditorViewCommand = {
 	command: "sherlock.openEditorView",
 	title: "Sherlock: Open Editor View",
 	register: commands.registerCommand,
 	callback: async function (args: { bundleId: string }) {
-		const context = vscode.extensions.getExtension("inlang.vs-code-extension")?.exports.context
+		const extensionUri = vscode.extensions.getExtension("inlang.vs-code-extension")?.extensionUri
+		const lease = getProjectRuntime<InlangProject>().activeProject()
 
-		if (!context) {
-			console.error("Extension context is not available.")
+		if (!extensionUri || !lease) {
+			console.error("Extension environment or active project is not available.")
 			return
 		}
 
-		const editor = editorView({ context, initialBundleId: args.bundleId })
+		const editor = editorView({ extensionUri, lease, initialBundleId: args.bundleId })
+		if (!lease.own({ dispose: () => editor.dispose({ persist: true }) })) {
+			await editor.dispose()
+			return
+		}
 		await editor.createOrShowPanel()
 
 		capture({

--- a/src/commands/openEditorView.ts
+++ b/src/commands/openEditorView.ts
@@ -19,7 +19,12 @@ export const openEditorViewCommand = {
 		}
 
 		const editor = editorView({ extensionUri, lease, initialBundleId: args.bundleId })
-		if (!lease.own({ dispose: () => editor.dispose({ persist: true }) })) {
+		if (
+			!lease.own({
+				dispose: (reason) =>
+					reason === "shutdown" ? editor.dispose({ persist: true }) : editor.dispose(),
+			})
+		) {
 			await editor.dispose()
 			return
 		}

--- a/src/commands/previewLocaleCommand.test.ts
+++ b/src/commands/previewLocaleCommand.test.ts
@@ -6,6 +6,11 @@ import { CONFIGURATION } from "../configuration.js"
 import { state } from "../utilities/state.js"
 import { getPreviewLocale } from "../utilities/locale/getPreviewLocale.js"
 
+const runtimeLease = vi.hoisted(() => ({
+	runTask: vi.fn(),
+	isCurrent: vi.fn(),
+}))
+
 vi.mock("vscode", () => ({
 	window: { createQuickPick: vi.fn() },
 	commands: { registerCommand: vi.fn() },
@@ -17,6 +22,21 @@ vi.mock("../utilities/settings/statusBar.js", () => ({
 }))
 vi.mock("../utilities/state.js", () => ({
 	state: vi.fn(),
+}))
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						path: "/workspace/project.inlang",
+						isCurrent: runtimeLease.isCurrent,
+						runTask: runtimeLease.runTask,
+					}
+				: undefined
+		},
+	}),
 }))
 vi.mock("../configuration.js", () => ({
 	CONFIGURATION: {
@@ -63,6 +83,11 @@ const createQuickPickMock = (selectedLocale?: string) => {
 describe("previewLocaleCommand", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		runtimeLease.isCurrent.mockReset().mockReturnValue(true)
+		runtimeLease.runTask.mockReset().mockImplementation(async (task: () => Promise<unknown>) => ({
+			status: "completed",
+			value: await task(),
+		}))
 		vi.mocked(getPreviewLocale).mockResolvedValue("en")
 		vi.mocked(state).mockReturnValue({
 			project: {
@@ -109,6 +134,17 @@ describe("previewLocaleCommand", () => {
 		expect(CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire).not.toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire).not.toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire).not.toHaveBeenCalled()
+		expect(CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.fire).not.toHaveBeenCalled()
+	})
+
+	it("does not apply a locale chosen for a project that was replaced", async () => {
+		const quickPick = createQuickPickMock("fr")
+		vi.mocked(vscode.window.createQuickPick).mockReturnValue(quickPick as never)
+		runtimeLease.isCurrent.mockReturnValue(false)
+
+		await previewLocaleCommand.callback()
+
+		expect(settings.updateSetting).not.toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.fire).not.toHaveBeenCalled()
 	})
 })

--- a/src/commands/previewLocaleCommand.test.ts
+++ b/src/commands/previewLocaleCommand.test.ts
@@ -124,6 +124,29 @@ describe("previewLocaleCommand", () => {
 		expect(CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.fire).toHaveBeenCalledTimes(1)
 	})
 
+	it("reads the current preview locale while the project lease owns the query", async () => {
+		let taskIsRunning = false
+		runtimeLease.runTask.mockImplementation(async (task: () => Promise<unknown>) => {
+			taskIsRunning = true
+			try {
+				return { status: "completed", value: await task() }
+			} finally {
+				taskIsRunning = false
+			}
+		})
+		vi.mocked(getPreviewLocale).mockImplementation(async () => {
+			expect(taskIsRunning).toBe(true)
+			return "en"
+		})
+		const quickPick = createQuickPickMock()
+		vi.mocked(vscode.window.createQuickPick).mockReturnValue(quickPick as never)
+
+		await previewLocaleCommand.callback()
+
+		expect(runtimeLease.runTask).toHaveBeenCalledTimes(1)
+		expect(getPreviewLocale).toHaveBeenCalledTimes(1)
+	})
+
 	it("should not update setting if no tag is selected", async () => {
 		const quickPick = createQuickPickMock()
 		vi.mocked(vscode.window.createQuickPick).mockReturnValue(quickPick as never)

--- a/src/commands/previewLocaleCommand.ts
+++ b/src/commands/previewLocaleCommand.ts
@@ -7,9 +7,8 @@ import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 const showPreviewLocalePicker = async (
 	locales: string[],
-	project: InlangProject
+	previewLocale: string | undefined
 ): Promise<string | undefined> => {
-	const previewLocale = await getPreviewLocale(project)
 	const quickPick = vscode.window.createQuickPick()
 	quickPick.placeholder = "Select a language"
 	quickPick.items = locales.map((locale) => ({ label: locale }))
@@ -36,9 +35,18 @@ export const previewLocaleCommand = {
 	callback: async () => {
 		const lease = getProjectRuntime<InlangProject>().activeProject()
 		if (!lease) return
-		const settings = await lease.runTask(() => lease.project.settings.get())
-		if (settings.status !== "completed") return
-		const selectedLocale = await showPreviewLocalePicker(settings.value.locales, lease.project)
+		const preview = await lease.runTask(async () => {
+			const settings = await lease.project.settings.get()
+			return {
+				locales: settings.locales,
+				previewLocale: await getPreviewLocale(lease.project),
+			}
+		})
+		if (preview.status !== "completed") return
+		const selectedLocale = await showPreviewLocalePicker(
+			preview.value.locales,
+			preview.value.previewLocale
+		)
 
 		if (!selectedLocale || !lease.isCurrent()) {
 			return

--- a/src/commands/previewLocaleCommand.ts
+++ b/src/commands/previewLocaleCommand.ts
@@ -1,11 +1,15 @@
 import * as vscode from "vscode"
 import { updateSetting } from "../utilities/settings/index.js"
-import { state } from "../utilities/state.js"
 import { CONFIGURATION } from "../configuration.js"
 import { getPreviewLocale } from "../utilities/locale/getPreviewLocale.js"
+import type { InlangProject } from "@inlang/sdk"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
-const showPreviewLocalePicker = async (locales: string[]): Promise<string | undefined> => {
-	const previewLocale = await getPreviewLocale()
+const showPreviewLocalePicker = async (
+	locales: string[],
+	project: InlangProject
+): Promise<string | undefined> => {
+	const previewLocale = await getPreviewLocale(project)
 	const quickPick = vscode.window.createQuickPick()
 	quickPick.placeholder = "Select a language"
 	quickPick.items = locales.map((locale) => ({ label: locale }))
@@ -30,10 +34,13 @@ export const previewLocaleCommand = {
 	title: "Sherlock: Change preview language tag",
 	register: vscode.commands.registerCommand,
 	callback: async () => {
-		const settings = await state().project?.settings.get()
-		const selectedLocale = await showPreviewLocalePicker(settings.locales)
+		const lease = getProjectRuntime<InlangProject>().activeProject()
+		if (!lease) return
+		const settings = await lease.runTask(() => lease.project.settings.get())
+		if (settings.status !== "completed") return
+		const selectedLocale = await showPreviewLocalePicker(settings.value.locales, lease.project)
 
-		if (!selectedLocale) {
+		if (!selectedLocale || !lease.isCurrent()) {
 			return
 		}
 

--- a/src/commands/reloadProject.test.ts
+++ b/src/commands/reloadProject.test.ts
@@ -4,6 +4,10 @@ import { reloadProjectCommand } from "./reloadProject.js"
 import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 const replaceProject = vi.hoisted(() => vi.fn())
+const activeProject = vi.hoisted(() =>
+	vi.fn<() => { path: string } | undefined>(() => ({ path: "/workspace/project.inlang" }))
+)
+const lastRequestedProjectPath = vi.hoisted(() => vi.fn(() => "/workspace/project.inlang"))
 
 vi.mock("vscode", () => ({
 	commands: { registerCommand: vi.fn() },
@@ -12,7 +16,8 @@ vi.mock("vscode", () => ({
 
 vi.mock("../utilities/project/projectRuntime.js", () => ({
 	getProjectRuntime: vi.fn(() => ({
-		activeProject: () => ({ path: "/workspace/project.inlang" }),
+		activeProject,
+		lastRequestedProjectPath,
 		replaceProject,
 	})),
 }))
@@ -22,6 +27,8 @@ vi.mock("../utilities/utils.js", () => ({ handleError: vi.fn() }))
 describe("reloadProjectCommand", () => {
 	beforeEach(() => {
 		replaceProject.mockReset().mockResolvedValue({ status: "committed" })
+		activeProject.mockReset().mockReturnValue({ path: "/workspace/project.inlang" })
+		lastRequestedProjectPath.mockReset().mockReturnValue("/workspace/project.inlang")
 	})
 
 	it("replaces the active session without activating the extension again", async () => {
@@ -29,5 +36,13 @@ describe("reloadProjectCommand", () => {
 
 		expect(getProjectRuntime().replaceProject).toHaveBeenCalledWith("/workspace/project.inlang")
 		expect(vscode.commands.registerCommand).not.toHaveBeenCalled()
+	})
+
+	it("retries the last requested path after startup loading failed", async () => {
+		activeProject.mockReturnValue(undefined)
+
+		await expect(reloadProjectCommand.callback()).resolves.toBe("committed")
+
+		expect(replaceProject).toHaveBeenCalledWith("/workspace/project.inlang")
 	})
 })

--- a/src/commands/reloadProject.test.ts
+++ b/src/commands/reloadProject.test.ts
@@ -1,0 +1,33 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import * as vscode from "vscode"
+import { reloadProjectCommand } from "./reloadProject.js"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
+
+const replaceProject = vi.hoisted(() => vi.fn())
+
+vi.mock("vscode", () => ({
+	commands: { registerCommand: vi.fn() },
+	workspace: { workspaceFolders: [{ uri: { fsPath: "/workspace" } }] },
+}))
+
+vi.mock("../utilities/project/projectRuntime.js", () => ({
+	getProjectRuntime: vi.fn(() => ({
+		activeProject: () => ({ path: "/workspace/project.inlang" }),
+		replaceProject,
+	})),
+}))
+
+vi.mock("../utilities/utils.js", () => ({ handleError: vi.fn() }))
+
+describe("reloadProjectCommand", () => {
+	beforeEach(() => {
+		replaceProject.mockReset().mockResolvedValue({ status: "committed" })
+	})
+
+	it("replaces the active session without activating the extension again", async () => {
+		await expect(reloadProjectCommand.callback()).resolves.toBe("committed")
+
+		expect(getProjectRuntime().replaceProject).toHaveBeenCalledWith("/workspace/project.inlang")
+		expect(vscode.commands.registerCommand).not.toHaveBeenCalled()
+	})
+})

--- a/src/commands/reloadProject.ts
+++ b/src/commands/reloadProject.ts
@@ -1,9 +1,6 @@
 import * as vscode from "vscode"
 import { handleError } from "../utilities/utils.js"
-import { state } from "../utilities/state.js"
-import { main } from "../main.js"
-import { createFileSystemMapper } from "../utilities/fs/createFileSystemMapper.js"
-import fs from "node:fs/promises"
+import { getProjectRuntime } from "../utilities/project/projectRuntime.js"
 
 export const reloadProjectCommand = {
 	command: "sherlock.reloadProject",
@@ -17,34 +14,23 @@ export const reloadProjectCommand = {
 			const workspaceFolder = vscode.workspace.workspaceFolders?.[0]
 			if (!workspaceFolder) {
 				console.warn("No workspace folder found.")
-				return
+				return "no-workspace" as const
 			}
 
-			// Create file system mapper
-			const mappedFs = createFileSystemMapper(workspaceFolder.uri.fsPath, fs)
-
-			// Get context from extension
-			const extension = vscode.extensions.getExtension("inlang.vs-code-extension")
-			if (!extension) {
-				throw new Error("Could not find Sherlock extension")
-			}
-
-			// Get API from extension (returns context)
-			const api = await extension.activate()
-			if (!api?.context) {
-				throw new Error("Could not get extension context")
-			}
-
-			// Update project if we have a selected project
-			if (state().selectedProjectPath) {
-				await main({ context: api.context, workspaceFolder, fs: mappedFs })
-				console.log("Project reloaded successfully")
+			const activeProject = getProjectRuntime().activeProject()
+			if (activeProject) {
+				const result = await getProjectRuntime().replaceProject(activeProject.path)
+				if (result.status === "failed") throw result.error
+				if (result.status === "committed") console.log("Project reloaded successfully")
+				return result.status
 			} else {
 				console.warn("No project selected, nothing to reload")
+				return "no-project" as const
 			}
 		} catch (error) {
 			console.error("Failed to reload project:", error)
 			handleError(error)
+			return "failed" as const
 		}
 	},
 }

--- a/src/commands/reloadProject.ts
+++ b/src/commands/reloadProject.ts
@@ -17,9 +17,10 @@ export const reloadProjectCommand = {
 				return "no-workspace" as const
 			}
 
-			const activeProject = getProjectRuntime().activeProject()
-			if (activeProject) {
-				const result = await getProjectRuntime().replaceProject(activeProject.path)
+			const runtime = getProjectRuntime()
+			const projectPath = runtime.activeProject()?.path ?? runtime.lastRequestedProjectPath()
+			if (projectPath) {
+				const result = await runtime.replaceProject(projectPath)
 				if (result.status === "failed") throw result.error
 				if (result.status === "committed") console.log("Project reloaded successfully")
 				return result.status

--- a/src/configuration.ts
+++ b/src/configuration.ts
@@ -20,6 +20,7 @@ export const CONFIGURATION = {
 		ON_DID_CREATE_MESSAGE: new EventEmitter<void>(),
 		ON_DID_EDIT_MESSAGE: new EventEmitter<void>(),
 		ON_DID_EXTRACT_MESSAGE: new EventEmitter<void>(),
+		ON_DID_PROJECT_CHANGE: new EventEmitter<void>(),
 		ON_DID_PROJECT_TREE_VIEW_CHANGE: new EventEmitter<ProjectViewNode | undefined>(),
 		ON_DID_ERROR_TREE_VIEW_CHANGE: new EventEmitter<ErrorNode | undefined>(),
 		ON_DID_PREVIEW_LOCALE_CHANGE: new EventEmitter<string>(),

--- a/src/decorations/contextTooltip.ts
+++ b/src/decorations/contextTooltip.ts
@@ -5,7 +5,8 @@ import { getStringFromPattern } from "../utilities/messages/query.js"
 import { INTERPOLATE } from "../configuration.js"
 import { escapeHtml } from "../utilities/utils.js"
 import { type IdeExtensionConfig } from "@inlang/sdk"
-import { getSelectedBundleByBundleIdOrAlias } from "../utilities/helper.js"
+import type { InlangProject } from "@inlang/sdk"
+import { selectBundleById } from "../utilities/project/selectBundleById.js"
 
 const MISSING_TRANSLATION_MESSAGE = "[missing]"
 
@@ -36,25 +37,22 @@ function renderTranslationRow(row: ContextTableRow) {
 export async function contextTooltip(
 	referenceMessage: Awaited<
 		ReturnType<IdeExtensionConfig["messageReferenceMatchers"][number]>
-	>[number]
+	>[number],
+	project: InlangProject | undefined = state().project
 ) {
-	const context = vscode.extensions.getExtension("inlang.vs-code-extension")?.exports.context
-	if (!context) {
-		console.error("Extension context is not available.")
-		return
-	}
+	if (!project) return
 
 	// @ts-ignore TODO: Introduce deprecation message for messageId
 	referenceMessage.bundleId = referenceMessage.bundleId || referenceMessage.messageId
 	// resolve message from id or alias
-	const bundle = await getSelectedBundleByBundleIdOrAlias(referenceMessage.bundleId)
+	const bundle = await selectBundleById(project, referenceMessage.bundleId)
 
 	if (!bundle) {
 		return undefined // Return early if message is not found
 	}
 
 	// Get the configured language tags
-	const configuredLanguageTags = (await state().project.settings.get())?.locales || []
+	const configuredLanguageTags = (await project.settings.get())?.locales || []
 
 	// Generate rows for each configured language tag
 	const contextTableRows: ContextTableRow[] = await Promise.all(

--- a/src/decorations/messagePreview.test.ts
+++ b/src/decorations/messagePreview.test.ts
@@ -6,7 +6,8 @@ const mocks = vi.hoisted(() => ({
 	getPreviewLocale: vi.fn(),
 	getSetting: vi.fn(),
 	getExtensionApi: vi.fn(),
-	getSelectedBundleByBundleIdOrAlias: vi.fn(),
+	selectBundleById: vi.fn(),
+	projectChangeListener: undefined as (() => void) | undefined,
 }))
 
 vi.mock("vscode", () => ({
@@ -67,12 +68,21 @@ vi.mock("../utilities/settings/index.js", () => ({
 
 vi.mock("../utilities/helper.js", () => ({
 	getExtensionApi: mocks.getExtensionApi,
-	getSelectedBundleByBundleIdOrAlias: mocks.getSelectedBundleByBundleIdOrAlias,
+}))
+
+vi.mock("../utilities/project/selectBundleById.js", () => ({
+	selectBundleById: mocks.selectBundleById,
 }))
 
 vi.mock("../configuration.js", () => ({
 	CONFIGURATION: {
 		EVENTS: {
+			ON_DID_PROJECT_CHANGE: {
+				event: vi.fn((listener: () => void) => {
+					mocks.projectChangeListener = listener
+					return { dispose: vi.fn() }
+				}),
+			},
 			ON_DID_CREATE_MESSAGE: { event: vi.fn() },
 			ON_DID_EDIT_MESSAGE: { event: vi.fn() },
 			ON_DID_EXTRACT_MESSAGE: { event: vi.fn() },
@@ -84,6 +94,7 @@ vi.mock("../configuration.js", () => ({
 describe("messagePreview", () => {
 	beforeEach(() => {
 		vi.clearAllMocks()
+		mocks.projectChangeListener = undefined
 		mocks.getPreviewLocale.mockResolvedValue("en")
 		mocks.getSetting.mockResolvedValue("transparent")
 		mocks.getExtensionApi.mockResolvedValue({
@@ -99,7 +110,7 @@ describe("messagePreview", () => {
 				]),
 			],
 		})
-		mocks.getSelectedBundleByBundleIdOrAlias.mockResolvedValue({
+		mocks.selectBundleById.mockResolvedValue({
 			messages: [
 				{
 					locale: "ckb",
@@ -126,7 +137,24 @@ describe("messagePreview", () => {
 	})
 
 	it("renders the message for the selected preview locale", async () => {
-		await messagePreview({ context: { subscriptions: [] } as never })
+		const project = {
+			settings: {
+				get: vi.fn(async () => ({ baseLocale: "ckb", locales: ["ckb", "en"] })),
+			},
+		}
+		messagePreview({
+			subscriptions: [],
+			session: {
+				path: "/workspace/project.inlang",
+				project,
+				runTask: async <T>(task: () => Promise<T>) => ({
+					status: "completed" as const,
+					value: await task(),
+				}),
+			} as never,
+		})
+		expect(mocks.setDecorations).not.toHaveBeenCalled()
+		mocks.projectChangeListener?.()
 
 		await vi.waitFor(() => {
 			expect(mocks.setDecorations).toHaveBeenCalledWith(expect.anything(), [
@@ -137,5 +165,29 @@ describe("messagePreview", () => {
 				}),
 			])
 		})
+	})
+
+	it("does not apply decorations computed by a session that became inactive", async () => {
+		const project = {
+			settings: {
+				get: vi.fn(async () => ({ baseLocale: "ckb", locales: ["ckb", "en"] })),
+			},
+		}
+		messagePreview({
+			subscriptions: [],
+			session: {
+				path: "/workspace/project.inlang",
+				project,
+				runTask: async <T>(task: () => Promise<T>) => {
+					await task()
+					return { status: "inactive" as const }
+				},
+			} as never,
+		})
+
+		mocks.projectChangeListener?.()
+		await vi.waitFor(() => expect(mocks.selectBundleById).toHaveBeenCalled())
+
+		expect(mocks.setDecorations).not.toHaveBeenCalled()
 	})
 })

--- a/src/decorations/messagePreview.ts
+++ b/src/decorations/messagePreview.ts
@@ -1,159 +1,181 @@
 import * as vscode from "vscode"
-import { state } from "../utilities/state.js"
 import { contextTooltip } from "./contextTooltip.js"
 import { getStringFromPattern } from "../utilities/messages/query.js"
 import { CONFIGURATION } from "../configuration.js"
 import { resolveEscapedCharacters } from "../utilities/messages/resolveEscapedCharacters.js"
 import { getPreviewLocale } from "../utilities/locale/getPreviewLocale.js"
 import { getSetting } from "../utilities/settings/index.js"
-import { getExtensionApi, getSelectedBundleByBundleIdOrAlias } from "../utilities/helper.js"
+import { getExtensionApi } from "../utilities/helper.js"
+import { selectBundleById } from "../utilities/project/selectBundleById.js"
+import type { InlangProject } from "@inlang/sdk"
+import {
+	deactivateBeforeClose,
+	type Disposable,
+	type ProjectSession,
+} from "../utilities/project/projectSession.js"
+import { handleError } from "../utilities/utils.js"
 
 const MAXIMUM_PREVIEW_LENGTH = 40
 
-export async function messagePreview(args: { context: vscode.ExtensionContext }) {
+export function messagePreview(args: {
+	subscriptions: Disposable[]
+	session: ProjectSession<InlangProject>
+}) {
 	const messagePreview = vscode.window.createTextEditorDecorationType({})
-
-	async function updateDecorations() {
-		const activeTextEditor = vscode.window.activeTextEditor
-		const inlineAnnotationsEnabled = vscode.workspace
-			.getConfiguration()
-			.get<boolean>("sherlock.inlineAnnotations.enabled", true)
-
-		if (!activeTextEditor) {
-			return
-		}
-
-		// TODO: this is a hack to prevent the message preview from showing up in the project.inlang/settings file
-		if (activeTextEditor.document.fileName.includes("project.inlang")) {
-			return activeTextEditor.setDecorations(messagePreview, [])
-		}
-
-		// Get the reference language
-		const baseLocale = (await state().project.settings.get()).baseLocale
-		const extensionApi = await getExtensionApi()
-
-		if (!extensionApi) return
-
-		if (baseLocale === undefined || extensionApi.messageReferenceMatchers === undefined) {
-			// don't show an error message. See issue:
-			// https://github.com/opral/monorepo/issues/927
-			return
-		}
-
-		const editorInfoColors = {
-			foreground: await getSetting("editorColors.info.foreground").catch(
-				() => new vscode.ThemeColor("editorInfo.foreground")
-			),
-			background: await getSetting("editorColors.info.background").catch(
-				() => new vscode.ThemeColor("editorInfo.background")
-			),
-			border: await getSetting("editorColors.info.border").catch(
-				() => new vscode.ThemeColor("editorInfo.border")
-			),
-		}
-		const editorErrorColors = {
-			foreground: await getSetting("editorColors.error.foreground").catch(
-				() => new vscode.ThemeColor("editorError.foreground")
-			),
-			background: await getSetting("editorColors.error.background").catch(
-				() => new vscode.ThemeColor("editorError.background")
-			),
-			border: await getSetting("editorColors.error.border").catch(
-				() => new vscode.ThemeColor("editorError.border")
-			),
-		}
-
-		// Get the message references
-		const wrappedDecorations = (extensionApi.messageReferenceMatchers ?? []).map(
-			async (matcher) => {
-				const bundles = await matcher({
-					documentText: activeTextEditor.document.getText(),
-				})
-
-				return bundles.map(async (bundle) => {
-					// @ts-ignore TODO: Introduce deprecation message for messageId
-					bundle.bundleId = bundle.bundleId || bundle.messageId
-					// Retrieve the bundle and messages
-					const _bundle = await getSelectedBundleByBundleIdOrAlias(bundle.bundleId)
-
-					const previewLocale = await getPreviewLocale()
-					const translationLocale = previewLocale.length ? previewLocale : baseLocale
-
-					// Get the message from the bundle
-					const message = _bundle?.messages.find((m) => m.locale === translationLocale)
-
-					const variant =
-						message?.variants.find((v) => v.matches.some((m) => m.type === "catchall-match")) ||
-						message?.variants[0]
-
-					const translationString = variant
-						? getStringFromPattern({
-								pattern: variant.pattern || [
-									{
-										type: "text",
-										value: "", // TODO: Fix pattern type to be always defined either/or Text / VariableReference
-									},
-								],
-								locale: translationLocale,
-								messageId: variant.messageId,
-							})
-						: ""
-
-					const translation = resolveEscapedCharacters(translationString)
-
-					const truncatedTranslation =
-						translation &&
-						(translation.length > (MAXIMUM_PREVIEW_LENGTH || 0)
-							? `${translation.slice(0, MAXIMUM_PREVIEW_LENGTH)}...`
-							: translation)
-
-					const range = new vscode.Range(
-						new vscode.Position(
-							bundle.position.start.line - 1,
-							bundle.position.start.character - 1
-						),
-						new vscode.Position(bundle.position.end.line - 1, bundle.position.end.character - 1)
-					)
-
-					const decoration: vscode.DecorationOptions = {
-						range,
-						renderOptions: inlineAnnotationsEnabled
-							? {
-									after: {
-										margin: "0 0.5rem",
-										contentText:
-											truncatedTranslation === "" || truncatedTranslation === undefined
-												? `ERROR: '${bundle.bundleId}' not found in source with language tag '${baseLocale}'`
-												: translation,
-										backgroundColor: translation
-											? editorInfoColors.background
-											: editorErrorColors.background,
-										color: translation ? editorInfoColors.foreground : editorErrorColors.foreground,
-										border: `1px solid ${
-											translation ? editorInfoColors.border : editorErrorColors.border
-										}`,
-									},
-								}
-							: undefined,
-						hoverMessage: await contextTooltip(bundle),
-					}
-					return decoration
-				})
-			}
-		)
-		const decorations = (await Promise.all(wrappedDecorations || [])).flat()
-		const unwrappedDecorations = await Promise.all(decorations)
-		activeTextEditor.setDecorations(messagePreview, unwrappedDecorations)
+	args.subscriptions.push(messagePreview)
+	const eventSubscriptions: vscode.Disposable[] = []
+	const ownEventSubscriptions = () => {
+		args.subscriptions.push(...eventSubscriptions.splice(0).map(deactivateBeforeClose))
 	}
 
-	// in case the active text editor is already open, update decorations
-	updateDecorations()
+	function updateDecorations() {
+		void (async () => {
+			const result = await args.session.runTask(async () => {
+				const project = args.session.project
+				const activeTextEditor = vscode.window.activeTextEditor
+				const inlineAnnotationsEnabled = vscode.workspace
+					.getConfiguration()
+					.get<boolean>("sherlock.inlineAnnotations.enabled", true)
+
+				if (!activeTextEditor) {
+					return
+				}
+
+				// TODO: this is a hack to prevent the message preview from showing up in the project.inlang/settings file
+				if (activeTextEditor.document.fileName.includes("project.inlang")) {
+					return { activeTextEditor, decorations: [] }
+				}
+
+				// Get the reference language
+				const baseLocale = (await project.settings.get()).baseLocale
+				const extensionApi = await getExtensionApi(project)
+
+				if (!extensionApi) return
+
+				if (baseLocale === undefined || extensionApi.messageReferenceMatchers === undefined) {
+					// don't show an error message. See issue:
+					// https://github.com/opral/monorepo/issues/927
+					return
+				}
+
+				const editorInfoColors = {
+					foreground: await getSetting("editorColors.info.foreground").catch(
+						() => new vscode.ThemeColor("editorInfo.foreground")
+					),
+					background: await getSetting("editorColors.info.background").catch(
+						() => new vscode.ThemeColor("editorInfo.background")
+					),
+					border: await getSetting("editorColors.info.border").catch(
+						() => new vscode.ThemeColor("editorInfo.border")
+					),
+				}
+				const editorErrorColors = {
+					foreground: await getSetting("editorColors.error.foreground").catch(
+						() => new vscode.ThemeColor("editorError.foreground")
+					),
+					background: await getSetting("editorColors.error.background").catch(
+						() => new vscode.ThemeColor("editorError.background")
+					),
+					border: await getSetting("editorColors.error.border").catch(
+						() => new vscode.ThemeColor("editorError.border")
+					),
+				}
+
+				// Get the message references
+				const wrappedDecorations = (extensionApi.messageReferenceMatchers ?? []).map(
+					async (matcher) => {
+						const bundles = await matcher({
+							documentText: activeTextEditor.document.getText(),
+						})
+
+						return bundles.map(async (bundle) => {
+							// @ts-ignore TODO: Introduce deprecation message for messageId
+							bundle.bundleId = bundle.bundleId || bundle.messageId
+							// Retrieve the bundle and messages
+							const _bundle = await selectBundleById(project, bundle.bundleId)
+
+							const previewLocale = await getPreviewLocale(project)
+							const translationLocale = previewLocale?.length ? previewLocale : baseLocale
+
+							// Get the message from the bundle
+							const message = _bundle?.messages.find((m) => m.locale === translationLocale)
+
+							const variant =
+								message?.variants.find((v) => v.matches.some((m) => m.type === "catchall-match")) ||
+								message?.variants[0]
+
+							const translationString = variant
+								? getStringFromPattern({
+										pattern: variant.pattern || [
+											{
+												type: "text",
+												value: "", // TODO: Fix pattern type to be always defined either/or Text / VariableReference
+											},
+										],
+										locale: translationLocale,
+										messageId: variant.messageId,
+									})
+								: ""
+
+							const translation = resolveEscapedCharacters(translationString)
+
+							const truncatedTranslation =
+								translation &&
+								(translation.length > (MAXIMUM_PREVIEW_LENGTH || 0)
+									? `${translation.slice(0, MAXIMUM_PREVIEW_LENGTH)}...`
+									: translation)
+
+							const range = new vscode.Range(
+								new vscode.Position(
+									bundle.position.start.line - 1,
+									bundle.position.start.character - 1
+								),
+								new vscode.Position(bundle.position.end.line - 1, bundle.position.end.character - 1)
+							)
+
+							const decoration: vscode.DecorationOptions = {
+								range,
+								renderOptions: inlineAnnotationsEnabled
+									? {
+											after: {
+												margin: "0 0.5rem",
+												contentText:
+													truncatedTranslation === "" || truncatedTranslation === undefined
+														? `ERROR: '${bundle.bundleId}' not found in source with language tag '${baseLocale}'`
+														: translation,
+												backgroundColor: translation
+													? editorInfoColors.background
+													: editorErrorColors.background,
+												color: translation
+													? editorInfoColors.foreground
+													: editorErrorColors.foreground,
+												border: `1px solid ${
+													translation ? editorInfoColors.border : editorErrorColors.border
+												}`,
+											},
+										}
+									: undefined,
+								hoverMessage: await contextTooltip(bundle, project),
+							}
+							return decoration
+						})
+					}
+				)
+				const decorations = (await Promise.all(wrappedDecorations || [])).flat()
+				const unwrappedDecorations = await Promise.all(decorations)
+				return { activeTextEditor, decorations: unwrappedDecorations }
+			})
+			if (result.status === "completed" && result.value) {
+				result.value.activeTextEditor.setDecorations(messagePreview, result.value.decorations)
+			}
+		})().catch(handleError)
+	}
 
 	// immediately update decorations when the active text editor changes
 	vscode.window.onDidChangeActiveTextEditor(
 		() => updateDecorations(),
 		undefined,
-		args.context.subscriptions
+		eventSubscriptions
 	)
 
 	// update decorations when the text changes in a document
@@ -164,17 +186,17 @@ export async function messagePreview(args: { context: vscode.ExtensionContext })
 			}
 		},
 		undefined,
-		args.context.subscriptions
+		eventSubscriptions
 	)
 
 	// update decorations, when message was edited / extracted
-	CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.event(() => {
-		updateDecorations()
-	})
-
-	CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.event(() => updateDecorations())
-	CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.event(() => updateDecorations())
-	CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.event(() => updateDecorations())
+	eventSubscriptions.push(
+		CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.event(() => updateDecorations()),
+		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.event(() => updateDecorations()),
+		CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.event(() => updateDecorations()),
+		CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.event(() => updateDecorations()),
+		CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.event(() => updateDecorations())
+	)
 
 	vscode.workspace.onDidChangeConfiguration(
 		(event) => {
@@ -183,6 +205,7 @@ export async function messagePreview(args: { context: vscode.ExtensionContext })
 			}
 		},
 		undefined,
-		args.context.subscriptions
+		eventSubscriptions
 	)
+	ownEventSubscriptions()
 }

--- a/src/diagnostics/lintRuleResolver.ts
+++ b/src/diagnostics/lintRuleResolver.ts
@@ -8,10 +8,11 @@ import {
 } from "../utilities/lint-rules/lintRules.js"
 import { state } from "../utilities/state.js"
 import * as vscode from "vscode"
+import type { InlangProject } from "@inlang/sdk"
 
 export interface LintRule {
 	name: string // The name of the lint rule (e.g., "missingMessage", "bundleWithoutMessageWithBaseLocale")
-	ruleFn: (bundleId: string) => Promise<LintResult[]> // The linting function that runs on a bundle and returns lint results
+	ruleFn: (bundleId: string, project?: InlangProject) => Promise<LintResult[]> // The linting function that runs on a bundle and returns lint results
 }
 
 // Map of available custom lint rules with updated names
@@ -38,8 +39,9 @@ const customLintRules: Record<string, LintRule> = {
 	},
 }
 
-export async function resolveLintRules() {
-	const settings = await state().project.settings.get()
+export async function resolveLintRules(project: InlangProject | undefined = state().project) {
+	if (!project) return []
+	const settings = await project.settings.get()
 	const lintRuleLevels = settings.messageLintRuleLevels || {}
 	const activeRules: LintRule[] = []
 
@@ -54,7 +56,7 @@ export async function resolveLintRules() {
 
 		if (customRule) {
 			const severity = lintRuleLevels[`messageLintRule.inlang.${moduleName}`] || "error" // Default to error if not specified
-			const wrappedRuleFn = wrapLintRuleWithSeverity(customRule.ruleFn, severity)
+			const wrappedRuleFn = wrapLintRuleWithSeverity(customRule.ruleFn, severity, project)
 
 			// Ensure that 'name' is present and not undefined
 			activeRules.push({
@@ -69,11 +71,12 @@ export async function resolveLintRules() {
 }
 
 export function wrapLintRuleWithSeverity(
-	ruleFn: (bundleId: string) => Promise<LintResult[]>,
-	severity: string
+	ruleFn: (bundleId: string, project?: InlangProject) => Promise<LintResult[]>,
+	severity: string,
+	project?: InlangProject
 ) {
 	return async (bundleId: string) => {
-		const results = await ruleFn(bundleId)
+		const results = project ? await ruleFn(bundleId, project) : await ruleFn(bundleId)
 		return results.map((result) => ({
 			...result,
 			severity: mapSeverity(severity),

--- a/src/diagnostics/linterDiagnostics.test.ts
+++ b/src/diagnostics/linterDiagnostics.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import { linterDiagnostics } from "./linterDiagnostics.js"
+
+const mocks = vi.hoisted(() => ({
+	setDiagnostics: vi.fn(),
+	projectChangeListener: undefined as (() => void) | undefined,
+}))
+
+vi.mock("vscode", () => ({
+	window: {
+		activeTextEditor: {
+			document: { getText: vi.fn(() => "m.hello()"), uri: { path: "/workspace/page.ts" } },
+		},
+		onDidChangeActiveTextEditor: vi.fn(),
+	},
+	workspace: { onDidChangeTextDocument: vi.fn() },
+	languages: {
+		createDiagnosticCollection: vi.fn(() => ({
+			set: mocks.setDiagnostics,
+			dispose: vi.fn(),
+		})),
+	},
+	Range: class {},
+	Position: class {},
+	Diagnostic: class {},
+}))
+
+vi.mock("../configuration.js", () => ({
+	CONFIGURATION: {
+		EVENTS: {
+			ON_DID_PROJECT_CHANGE: {
+				event: vi.fn((listener: () => void) => {
+					mocks.projectChangeListener = listener
+					return { dispose: vi.fn() }
+				}),
+			},
+		},
+	},
+}))
+
+vi.mock("../utilities/helper.js", () => ({
+	getExtensionApi: vi.fn(async () => ({ messageReferenceMatchers: [] })),
+}))
+
+vi.mock("./lintRuleResolver.js", () => ({ resolveLintRules: vi.fn(async () => []) }))
+vi.mock("../utilities/project/selectBundleById.js", () => ({ selectBundleById: vi.fn() }))
+vi.mock("../utilities/utils.js", () => ({ handleError: vi.fn() }))
+
+describe("linterDiagnostics", () => {
+	beforeEach(() => {
+		vi.clearAllMocks()
+		mocks.projectChangeListener = undefined
+	})
+
+	it("refreshes exactly once from the coherent project-change signal", async () => {
+		await linterDiagnostics({
+			subscriptions: [],
+			fs: {} as never,
+			session: {
+				project: {},
+				runTask: async <T>(task: () => Promise<T>) => ({
+					status: "completed" as const,
+					value: await task(),
+				}),
+			} as never,
+		})
+
+		expect(mocks.setDiagnostics).not.toHaveBeenCalled()
+		mocks.projectChangeListener?.()
+		await vi.waitFor(() => expect(mocks.setDiagnostics).toHaveBeenCalledTimes(1))
+	})
+
+	it("does not publish diagnostics computed by an inactive session", async () => {
+		await linterDiagnostics({
+			subscriptions: [],
+			fs: {} as never,
+			session: {
+				project: {},
+				runTask: async <T>(task: () => Promise<T>) => {
+					await task()
+					return { status: "inactive" as const }
+				},
+			} as never,
+		})
+
+		mocks.projectChangeListener?.()
+		await Promise.resolve()
+		expect(mocks.setDiagnostics).not.toHaveBeenCalled()
+	})
+})

--- a/src/diagnostics/linterDiagnostics.ts
+++ b/src/diagnostics/linterDiagnostics.ts
@@ -2,91 +2,106 @@
 import * as vscode from "vscode"
 import { resolveLintRules } from "./lintRuleResolver.js"
 import type { FileSystem } from "../utilities/fs/createFileSystemMapper.js"
-import { getExtensionApi, getSelectedBundleByBundleIdOrAlias } from "../utilities/helper.js"
+import { getExtensionApi } from "../utilities/helper.js"
+import type { InlangProject } from "@inlang/sdk"
+import {
+	deactivateBeforeClose,
+	type Disposable,
+	type ProjectSession,
+} from "../utilities/project/projectSession.js"
+import { selectBundleById } from "../utilities/project/selectBundleById.js"
+import { handleError } from "../utilities/utils.js"
+import { CONFIGURATION } from "../configuration.js"
 
 export async function linterDiagnostics(args: {
-	context: vscode.ExtensionContext
+	subscriptions: Disposable[]
 	fs: FileSystem
+	session: ProjectSession<InlangProject>
 }) {
 	const linterDiagnosticCollection = vscode.languages.createDiagnosticCollection("inlang-lint")
+	args.subscriptions.push(linterDiagnosticCollection)
+	const eventSubscriptions: vscode.Disposable[] = []
 
-	async function updateLintDiagnostics() {
-		const activeTextEditor = vscode.window.activeTextEditor
-		if (!activeTextEditor) return
+	function updateLintDiagnostics() {
+		void (async () => {
+			const result = await args.session.runTask(async () => {
+				const project = args.session.project
+				const activeTextEditor = vscode.window.activeTextEditor
+				if (!activeTextEditor) return
 
-		const documentText = activeTextEditor.document.getText()
-		const extensionApi = await getExtensionApi()
+				const documentText = activeTextEditor.document.getText()
+				const extensionApi = await getExtensionApi(project)
 
-		if (!extensionApi) return
+				if (!extensionApi) return
 
-		// Process messageReferenceMatchers to match bundles
-		const messageReferenceMatchers = extensionApi.messageReferenceMatchers ?? []
-		const activeLintRules = await resolveLintRules()
-		const diagnostics: vscode.Diagnostic[] = []
+				// Process messageReferenceMatchers to match bundles
+				const messageReferenceMatchers = extensionApi.messageReferenceMatchers ?? []
+				const activeLintRules = await resolveLintRules(project)
+				const diagnostics: vscode.Diagnostic[] = []
 
-		// Run each matcher on the document text
-		const wrappedLints = messageReferenceMatchers.map(async (matcher) => {
-			const bundles = await matcher({ documentText })
+				// Run each matcher on the document text
+				const wrappedLints = messageReferenceMatchers.map(async (matcher) => {
+					const bundles = await matcher({ documentText })
 
-			const diagnosticsIndex: Record<string, Record<string, vscode.Diagnostic[]>> = {}
+					const diagnosticsIndex: Record<string, Record<string, vscode.Diagnostic[]>> = {}
 
-			for (const bundle of bundles) {
-				// @ts-ignore TODO: Introduce deprecation message for messageId
-				bundle.bundleId = bundle.bundleId || bundle.messageId
-				// Retrieve the bundle and messages
-				const _bundle = await getSelectedBundleByBundleIdOrAlias(bundle.bundleId)
-
-				if (_bundle) {
-					for (const lintRule of activeLintRules) {
+					for (const bundle of bundles) {
 						// @ts-ignore TODO: Introduce deprecation message for messageId
-						const lintResults = await lintRule.ruleFn(bundle.bundleId)
+						bundle.bundleId = bundle.bundleId || bundle.messageId
+						// Retrieve the bundle and messages
+						const _bundle = await selectBundleById(project, bundle.bundleId)
 
-						for (const result of lintResults) {
-							const diagnosticRange = new vscode.Range(
-								new vscode.Position(0, 0), // Adjust based on actual range from matcher
-								new vscode.Position(0, 1)
-							)
+						if (_bundle) {
+							for (const lintRule of activeLintRules) {
+								// @ts-ignore TODO: Introduce deprecation message for messageId
+								const lintResults = await lintRule.ruleFn(bundle.bundleId, project)
 
-							const diagnostic = new vscode.Diagnostic(
-								diagnosticRange,
-								`[${result.code}] - ${result.description}`,
-								result.severity
-							)
+								for (const result of lintResults) {
+									const diagnosticRange = new vscode.Range(
+										new vscode.Position(0, 0), // Adjust based on actual range from matcher
+										new vscode.Position(0, 1)
+									)
 
-							// Create index for diagnostics if missing
-							if (!diagnosticsIndex[bundle.bundleId]) {
-								diagnosticsIndex[bundle.bundleId] = {}
+									const diagnostic = new vscode.Diagnostic(
+										diagnosticRange,
+										`[${result.code}] - ${result.description}`,
+										result.severity
+									)
+
+									// Create index for diagnostics if missing
+									if (!diagnosticsIndex[bundle.bundleId]) {
+										diagnosticsIndex[bundle.bundleId] = {}
+									}
+
+									// Store the diagnostics
+									const rangeIndex = getRangeIndex(diagnostic.range)
+									if (!diagnosticsIndex[bundle.bundleId]![rangeIndex]) {
+										diagnosticsIndex[bundle.bundleId]![rangeIndex] = []
+									}
+									// Typescript doesn't understand that diagnosticsIndex[bundle.bundleId]![rangeIndex] is an empty array if it doesn't exist
+									// @ts-expect-error
+									diagnosticsIndex[bundle.bundleId]![rangeIndex].push(diagnostic)
+								}
 							}
-
-							// Store the diagnostics
-							const rangeIndex = getRangeIndex(diagnostic.range)
-							if (!diagnosticsIndex[bundle.bundleId]![rangeIndex]) {
-								diagnosticsIndex[bundle.bundleId]![rangeIndex] = []
-							}
-							// Typescript doesn't understand that diagnosticsIndex[bundle.bundleId]![rangeIndex] is an empty array if it doesn't exist
-							// @ts-expect-error
-							diagnosticsIndex[bundle.bundleId]![rangeIndex].push(diagnostic)
 						}
 					}
-				}
+
+					// Collect all diagnostics
+					diagnostics.push(...flattenDiagnostics(diagnosticsIndex))
+				})
+
+				await Promise.all(wrappedLints || [])
+
+				return { uri: activeTextEditor.document.uri, diagnostics }
+			})
+			if (result.status === "completed" && result.value) {
+				linterDiagnosticCollection.set(result.value.uri, result.value.diagnostics)
 			}
-
-			// Collect all diagnostics
-			diagnostics.push(...flattenDiagnostics(diagnosticsIndex))
-		})
-
-		await Promise.all(wrappedLints || [])
-
-		// Set all the collected diagnostics at once
-		linterDiagnosticCollection.set(activeTextEditor.document.uri, diagnostics)
+		})().catch(handleError)
 	}
 
 	// Trigger diagnostics on active text editor change and text document change
-	vscode.window.onDidChangeActiveTextEditor(
-		updateLintDiagnostics,
-		undefined,
-		args.context.subscriptions
-	)
+	vscode.window.onDidChangeActiveTextEditor(updateLintDiagnostics, undefined, eventSubscriptions)
 	vscode.workspace.onDidChangeTextDocument(
 		(event) => {
 			if (event.document === vscode.window.activeTextEditor?.document) {
@@ -94,11 +109,12 @@ export async function linterDiagnostics(args: {
 			}
 		},
 		undefined,
-		args.context.subscriptions
+		eventSubscriptions
 	)
-
-	// Run diagnostics on initial load
-	updateLintDiagnostics()
+	eventSubscriptions.push(
+		CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.event(() => updateLintDiagnostics())
+	)
+	args.subscriptions.push(...eventSubscriptions.map(deactivateBeforeClose))
 }
 
 // Helper function to get a unique index for a range

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -255,4 +255,33 @@ describe("discoverProjectsInWorkspace", () => {
 		await deactivate()
 		expect(reloadedProject.close).toHaveBeenCalledTimes(1)
 	})
+
+	it("keeps global views and the runtime available after the initial project load fails", async () => {
+		const loadError = new Error("plugin failed to load")
+		const recoveredProject = {
+			plugins: { get: vi.fn(async () => []) },
+			settings: { get: vi.fn(async () => ({ locales: [] })) },
+			errors: { get: vi.fn(async () => []) },
+			close: vi.fn(async () => undefined),
+		}
+		const context = { subscriptions: [] } as unknown as vscode.ExtensionContext
+		vi.mocked(fg.async).mockResolvedValueOnce(["/workspace/project.inlang"])
+		vi.mocked(closestInlangProject).mockResolvedValueOnce({
+			projectPath: "/workspace/project.inlang",
+		} as any)
+		vi.mocked(loadProjectFromDirectory)
+			.mockRejectedValueOnce(loadError)
+			.mockResolvedValueOnce(recoveredProject as any)
+
+		await activate(context)
+
+		expect(handleError).toHaveBeenCalledWith(loadError)
+		expect(projectView).toHaveBeenCalledTimes(1)
+		expect(errorView).toHaveBeenCalledTimes(1)
+		expect(getProjectRuntime().lastRequestedProjectPath()).toBe("/workspace/project.inlang")
+		await expect(getProjectRuntime().replaceProject("/workspace/project.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+		expect(state().project).toBe(recoveredProject)
+	})
 })

--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -1,10 +1,19 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import * as vscode from "vscode"
 import fg from "fast-glob"
-import { activate, discoverProjectsInWorkspace } from "./main.js"
+import { activate, deactivate, discoverProjectsInWorkspace } from "./main.js"
 import { state } from "./utilities/state.js"
 import { handleError } from "./utilities/utils.js"
 import { gettingStartedView } from "./utilities/getting-started/gettingStarted.js"
+import { loadProjectFromDirectory } from "@inlang/sdk"
+import { closestInlangProject } from "./utilities/project/closestInlangProject.js"
+import { projectView } from "./utilities/project/project.js"
+import { messageView } from "./utilities/messages/messages.js"
+import { errorView } from "./utilities/errors/errors.js"
+import { recommendationBannerView } from "./utilities/recommendation/recommendation.js"
+import { getProjectRuntime } from "./utilities/project/projectRuntime.js"
+import { CONFIGURATION } from "./configuration.js"
+import { setupDirectMessageWatcher } from "./utilities/fs/experimental/directMessageHandler.js"
 
 vi.mock("vscode", () => ({
 	version: "1.90.0",
@@ -21,7 +30,7 @@ vi.mock("vscode", () => ({
 		showErrorMessage: vi.fn(),
 	},
 	languages: {
-		registerCodeActionsProvider: vi.fn(),
+		registerCodeActionsProvider: vi.fn(() => ({ dispose: vi.fn() })),
 	},
 	EventEmitter: class {
 		fire = vi.fn()
@@ -48,9 +57,26 @@ vi.mock("fast-glob", () => ({
 
 vi.mock("./configuration.js", () => ({
 	CONFIGURATION: {
-		COMMANDS: {},
+		COMMANDS: {
+			RELOAD: {
+				command: "sherlock.reloadProject",
+				callback: vi.fn(),
+				register: vi.fn(() => ({ dispose: vi.fn() })),
+			},
+		},
 		FILES: {
 			PROJECT: "project.inlang/settings.json",
+		},
+		EVENTS: {
+			ON_DID_EDIT_MESSAGE: { fire: vi.fn() },
+			ON_DID_CREATE_MESSAGE: { fire: vi.fn() },
+			ON_DID_EXTRACT_MESSAGE: { fire: vi.fn() },
+			ON_DID_PROJECT_CHANGE: {
+				fire: vi.fn(),
+				event: vi.fn(() => ({ dispose: vi.fn() })),
+			},
+			ON_DID_PROJECT_TREE_VIEW_CHANGE: { fire: vi.fn() },
+			ON_DID_ERROR_TREE_VIEW_CHANGE: { fire: vi.fn() },
 		},
 	},
 }))
@@ -118,6 +144,7 @@ vi.mock("./utilities/fs/experimental/directMessageHandler.js", () => ({
 
 vi.mock("@inlang/sdk", () => ({
 	saveProjectToDirectory: vi.fn(),
+	loadProjectFromDirectory: vi.fn(),
 }))
 
 describe("discoverProjectsInWorkspace", () => {
@@ -127,7 +154,8 @@ describe("discoverProjectsInWorkspace", () => {
 		},
 	} as vscode.WorkspaceFolder
 
-	beforeEach(() => {
+	beforeEach(async () => {
+		await deactivate()
 		vi.clearAllMocks()
 		;(
 			vscode.workspace as unknown as { workspaceFolders: vscode.WorkspaceFolder[] }
@@ -173,10 +201,58 @@ describe("discoverProjectsInWorkspace", () => {
 		} as unknown as vscode.ExtensionContext
 		vi.mocked(fg.async).mockRejectedValueOnce(error)
 
-		await expect(activate(context)).resolves.toEqual({ context })
+		await expect(activate(context)).resolves.toBeUndefined()
 
 		expect(handleError).toHaveBeenCalledWith(error)
 		expect(state().projectsInWorkspace).toEqual([])
 		expect(gettingStartedView).toHaveBeenCalledWith(expect.objectContaining({ workspaceFolder }))
+	})
+
+	it("registers global views once while replacing only the project session", async () => {
+		const firstProject = {
+			plugins: { get: vi.fn(async () => []) },
+			settings: { get: vi.fn(async () => ({ locales: [] })) },
+			errors: { get: vi.fn(async () => []) },
+			close: vi.fn(async () => undefined),
+		}
+		const reloadedProject = {
+			plugins: { get: vi.fn(async () => []) },
+			settings: { get: vi.fn(async () => ({ locales: [] })) },
+			errors: { get: vi.fn(async () => []) },
+			close: vi.fn(async () => undefined),
+		}
+		const context = { subscriptions: [] } as unknown as vscode.ExtensionContext
+		vi.mocked(fg.async).mockResolvedValueOnce(["/workspace/project.inlang"])
+		vi.mocked(closestInlangProject).mockResolvedValueOnce({
+			projectPath: "/workspace/project.inlang",
+		} as any)
+		vi.mocked(loadProjectFromDirectory)
+			.mockResolvedValueOnce(firstProject as any)
+			.mockResolvedValueOnce(reloadedProject as any)
+
+		await activate(context)
+		await getProjectRuntime().replaceProject("/workspace/project.inlang")
+
+		expect(projectView).toHaveBeenCalledTimes(1)
+		expect(messageView).toHaveBeenCalledTimes(1)
+		expect(errorView).toHaveBeenCalledTimes(1)
+		expect(recommendationBannerView).toHaveBeenCalledTimes(1)
+		expect(firstProject.close).toHaveBeenCalledTimes(1)
+		expect(setupDirectMessageWatcher).toHaveBeenCalledTimes(2)
+		const firstCodeActionProvider = vi.mocked(vscode.languages.registerCodeActionsProvider).mock
+			.results[0]?.value as vscode.Disposable
+		expect(firstCodeActionProvider.dispose).toHaveBeenCalledTimes(1)
+		expect(vi.mocked(firstCodeActionProvider.dispose).mock.invocationCallOrder[0]).toBeLessThan(
+			firstProject.close.mock.invocationCallOrder[0]!
+		)
+		expect(firstProject.close.mock.invocationCallOrder[0]).toBeLessThan(
+			vi.mocked(setupDirectMessageWatcher).mock.invocationCallOrder[1]!
+		)
+		expect(reloadedProject.close).not.toHaveBeenCalled()
+		expect(CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire).toHaveBeenCalledTimes(2)
+
+		await deactivate()
+		await deactivate()
+		expect(reloadedProject.close).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,13 +2,19 @@ import * as vscode from "vscode"
 import { handleError } from "./utilities/utils.js"
 import { CONFIGURATION } from "./configuration.js"
 import { projectView } from "./utilities/project/project.js"
-import { setProjectsInWorkspace, setState, state } from "./utilities/state.js"
+import {
+	prepareProject,
+	setActiveProject,
+	setProjectsInWorkspace,
+	state,
+} from "./utilities/state.js"
 import { messagePreview } from "./decorations/messagePreview.js"
 import { ExtractMessage } from "./actions/extractMessage.js"
 import { errorView } from "./utilities/errors/errors.js"
-import { messageView } from "./utilities/messages/messages.js"
+import { messageView, type MessageViewController } from "./utilities/messages/messages.js"
 import { createFileSystemMapper, type FileSystem } from "./utilities/fs/createFileSystemMapper.js"
 import fs from "node:fs/promises"
+import * as nodeFs from "node:fs"
 import { gettingStartedView } from "./utilities/getting-started/gettingStarted.js"
 import { closestInlangProject } from "./utilities/project/closestInlangProject.js"
 import { recommendationBannerView } from "./utilities/recommendation/recommendation.js"
@@ -16,10 +22,23 @@ import { capture } from "./services/telemetry/index.js"
 import packageJson from "../package.json" with { type: "json" }
 import { statusBar } from "./utilities/settings/statusBar.js"
 import fg from "fast-glob"
-import { saveProjectToDirectory, type IdeExtensionConfig } from "@inlang/sdk"
+import {
+	loadProjectFromDirectory,
+	saveProjectToDirectory,
+	type IdeExtensionConfig,
+	type InlangProject,
+} from "@inlang/sdk"
+import type { ActiveProjectLease } from "./utilities/project/projectRuntime.js"
 import path from "node:path"
 import { linterDiagnostics } from "./diagnostics/linterDiagnostics.js"
 import { setupDirectMessageWatcher } from "./utilities/fs/experimental/directMessageHandler.js"
+import { deactivateBeforeClose, type Disposable } from "./utilities/project/projectSession.js"
+import {
+	createProjectRuntime,
+	disposeProjectRuntime,
+	getProjectRuntime,
+	installProjectRuntime,
+} from "./utilities/project/projectRuntime.js"
 //import { initErrorMonitoring } from "./services/error-monitoring/implementation.js"
 
 const messageFileSnapshots = new Map<string, Set<string>>()
@@ -37,9 +56,7 @@ type DottedMessageKeySnapshot = {
 }
 
 // Entry Point
-export async function activate(
-	context: vscode.ExtensionContext
-): Promise<{ context: vscode.ExtensionContext } | undefined> {
+export async function activate(context: vscode.ExtensionContext): Promise<void> {
 	// Sentry Error Handling
 	//initErrorMonitoring()
 
@@ -56,7 +73,68 @@ export async function activate(
 		const mappedFs = createFileSystemMapper(path.normalize(workspaceFolder.uri.fsPath), fs)
 
 		await setProjects({ workspaceFolder })
-		await main({ context, workspaceFolder, fs: mappedFs })
+		registerGlobalCommands(context)
+		let messageController: MessageViewController | undefined
+		if (state().projectsInWorkspace.length > 0) {
+			messageController = await messageView({ context, workspaceFolder })
+		}
+		const runtime = createProjectRuntime({
+			loadProject: async (projectPath) => {
+				const project = await loadProjectFromDirectory({ path: projectPath, fs: nodeFs })
+				prepareProject(project)
+				return project
+			},
+			publishActiveSession: (session) =>
+				setActiveProject(session ? { project: session.project, path: session.path } : undefined),
+			prepareSession: async (session, resources) => {
+				const ideExtension = (await session.project.plugins.get()).find(
+					(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
+				)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
+				const documentSelectors: vscode.DocumentSelector = [
+					{ language: "javascript", pattern: `!${CONFIGURATION.FILES.PROJECT}` },
+					...(ideExtension?.documentSelectors ?? []),
+				]
+				return {
+					activate: () => {
+						resources.push(
+							deactivateBeforeClose(
+								vscode.languages.registerCodeActionsProvider(
+									documentSelectors,
+									new ExtractMessage(),
+									{ providedCodeActionKinds: ExtractMessage.providedCodeActionKinds }
+								)
+							)
+						)
+						messagePreview({ subscriptions: resources, session })
+						void linterDiagnostics({ subscriptions: resources, fs: mappedFs, session })
+						if (messageController) {
+							resources.push(deactivateBeforeClose(messageController.bindProject(session)))
+						}
+					},
+					afterPreviousDisposed: async () => {
+						await setupDirectMessageWatcher({
+							subscriptions: resources,
+							workspaceFolder,
+							session,
+						})
+						await session
+							.runTask(async () => {
+								resources.push(await seedMessageFileSnapshots(session.project, session.path))
+								await handleInlangErrors(session.project)
+							})
+							.catch(handleError)
+					},
+				}
+			},
+			onDidReplaceSession: notifyProjectChanged,
+			onError: (error) => handleError(error),
+		})
+		installProjectRuntime(runtime)
+		context.subscriptions.push({ dispose: () => void disposeProjectRuntime() })
+		await activateInitialProjectSession({ context, workspaceFolder, fs: mappedFs })
+		if (state().projectsInWorkspace.length > 0) {
+			await registerGlobalViews({ context, workspaceFolder, fs: mappedFs })
+		}
 
 		capture({
 			event: "IDE-EXTENSION activated",
@@ -66,16 +144,14 @@ export async function activate(
 				platform: process.platform,
 			},
 		})
-
-		return { context }
 	} catch (error) {
+		await disposeProjectRuntime()
 		handleError(error)
-		return
 	}
 }
 
 // Main Function
-export async function main(args: {
+async function activateInitialProjectSession(args: {
 	context: vscode.ExtensionContext
 	workspaceFolder: vscode.WorkspaceFolder
 	fs: FileSystem
@@ -87,38 +163,15 @@ export async function main(args: {
 			projects: state().projectsInWorkspace,
 		})
 
-		setState({
-			...state(),
-			selectedProjectPath:
-				closestProjectToWorkspace?.projectPath || state().projectsInWorkspace[0]?.projectPath || "",
-		})
+		const selectedProjectPath =
+			state().selectedProjectPath ||
+			closestProjectToWorkspace?.projectPath ||
+			state().projectsInWorkspace[0]?.projectPath ||
+			""
 
 		vscode.commands.executeCommand("setContext", "sherlock:hasProjectInWorkspace", true)
-
-		// Recommendation Banner
-		await recommendationBannerView(args)
-		// Project Listings
-		await projectView(args)
-		// Messages
-		await messageView(args)
-		// Errors
-		await errorView(args)
-		// Status Bar
-		await statusBar(args)
-
-		// Register Extension Components & Handle Inlang Errors
-		await registerExtensionComponents(args)
-		await handleInlangErrors()
-
-		// Set up both file system watchers
-		// setupFileSystemWatcher(args)
-
-		// Set up direct message watcher as a fallback
-		await seedMessageFileSnapshots()
-		await setupDirectMessageWatcher({
-			context: args.context,
-			workspaceFolder: args.workspaceFolder,
-		})
+		const result = await getProjectRuntime().replaceProject(selectedProjectPath)
+		if (result.status === "failed") throw result.error
 
 		return
 	} else {
@@ -126,37 +179,39 @@ export async function main(args: {
 	}
 }
 
-async function registerExtensionComponents(args: {
+function registerGlobalCommands(context: vscode.ExtensionContext) {
+	context.subscriptions.push(
+		...Object.values(CONFIGURATION.COMMANDS).map((command) =>
+			command.register(command.command, command.callback as any)
+		),
+		CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.event(() => {
+			CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.fire(undefined)
+			CONFIGURATION.EVENTS.ON_DID_ERROR_TREE_VIEW_CHANGE.fire(undefined)
+		})
+	)
+}
+
+async function registerGlobalViews(args: {
 	context: vscode.ExtensionContext
 	workspaceFolder: vscode.WorkspaceFolder
 	fs: FileSystem
 }) {
-	args.context.subscriptions.push(
-		...Object.values(CONFIGURATION.COMMANDS).map((c) => c.register(c.command, c.callback as any))
-	)
-
-	const ideExtension = (await state().project.plugins.get()).find(
-		(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
-	)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
-
-	const documentSelectors: vscode.DocumentSelector = [
-		{ language: "javascript", pattern: `!${CONFIGURATION.FILES.PROJECT}` },
-		...(ideExtension?.documentSelectors ?? []),
-	]
-
-	args.context.subscriptions.push(
-		vscode.languages.registerCodeActionsProvider(documentSelectors, new ExtractMessage(), {
-			providedCodeActionKinds: ExtractMessage.providedCodeActionKinds,
-		})
-	)
-
-	messagePreview(args)
-	// TODO: Replace by lix validation rules
-	linterDiagnostics(args)
+	await recommendationBannerView(args)
+	await projectView(args)
+	await errorView(args)
+	await statusBar(args)
 }
 
-async function handleInlangErrors() {
-	const inlangErrors = (await state().project.errors.get()) || []
+function notifyProjectChanged() {
+	CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire(undefined)
+}
+
+export async function deactivate() {
+	await disposeProjectRuntime()
+}
+
+async function handleInlangErrors(project: Awaited<ReturnType<typeof loadProjectFromDirectory>>) {
+	const inlangErrors = (await project.errors.get()) || []
 	if (inlangErrors.length > 0) {
 		console.error("Extension errors (Sherlock):", inlangErrors)
 	}
@@ -188,30 +243,37 @@ async function setProjects(args: { workspaceFolder: vscode.WorkspaceFolder }) {
 	setProjectsInWorkspace(await discoverProjectsInWorkspace(args))
 }
 
-export async function saveProject() {
+export async function saveProject(
+	lease:
+		| ActiveProjectLease<InlangProject>
+		| undefined = getProjectRuntime<InlangProject>().activeProject()
+) {
+	if (!lease) return
 	try {
-		if (state().selectedProjectPath && state().project) {
-			await removeMessagesDeletedFromJsonFiles()
-			const dottedKeySnapshots = await snapshotExplicitDottedMessageKeys()
-
-			await saveProjectToDirectory({
-				fs: createFileSystemMapper(state().selectedProjectPath, fs),
-				project: state().project,
-				path: state().selectedProjectPath,
-			})
-
-			await restoreExplicitDottedMessageKeys(dottedKeySnapshots)
-		}
+		await lease.runTask(() => saveProjectData(lease.project, lease.path))
 	} catch (error) {
 		handleError(error)
 	}
 }
 
-async function snapshotExplicitDottedMessageKeys(): Promise<DottedMessageKeySnapshot[]> {
-	const project = state().project
-	const selectedProjectPath = state().selectedProjectPath
-	if (!project || !selectedProjectPath) return []
+/** Persists a project that is still owned by a session during awaited teardown. */
+export async function saveProjectData(project: InlangProject, projectPath: string) {
+	await removeMessagesDeletedFromJsonFiles(project, projectPath)
+	const dottedKeySnapshots = await snapshotExplicitDottedMessageKeys(project, projectPath)
 
+	await saveProjectToDirectory({
+		fs: createFileSystemMapper(projectPath, fs),
+		project,
+		path: projectPath,
+	})
+
+	await restoreExplicitDottedMessageKeys(dottedKeySnapshots)
+}
+
+async function snapshotExplicitDottedMessageKeys(
+	project: InlangProject,
+	selectedProjectPath: string
+): Promise<DottedMessageKeySnapshot[]> {
 	const settings = await project.settings.get()
 	const pathPattern = getJsonPathPattern(settings)
 	if (!pathPattern) return []
@@ -281,11 +343,10 @@ async function restoreExplicitDottedMessageKeys(snapshots: DottedMessageKeySnaps
 	}
 }
 
-async function removeMessagesDeletedFromJsonFiles() {
-	const project = state().project
-	const selectedProjectPath = state().selectedProjectPath
-	if (!project || !selectedProjectPath) return
-
+async function removeMessagesDeletedFromJsonFiles(
+	project: InlangProject,
+	selectedProjectPath: string
+) {
 	const settings = await project.settings.get()
 	const baseLocale = settings.baseLocale ?? settings.locales[0]
 	const pathPattern = getJsonPathPattern(settings)
@@ -359,27 +420,37 @@ async function removeMessagesDeletedFromJsonFiles() {
 	}
 }
 
-async function seedMessageFileSnapshots() {
-	const project = state().project
-	const selectedProjectPath = state().selectedProjectPath
-	if (!project || !selectedProjectPath) return
+async function seedMessageFileSnapshots(
+	project: Awaited<ReturnType<typeof loadProjectFromDirectory>>,
+	selectedProjectPath: string
+): Promise<Disposable> {
+	const ownedSnapshots = new Map<string, Set<string>>()
 
 	const settings = await project.settings.get()
 	const pathPattern = getJsonPathPattern(settings)
-	if (!pathPattern) return
+	if (!pathPattern) return { dispose: () => undefined }
 
 	for (const locale of settings.locales) {
 		const messageFilePath = getMessageFilePath(selectedProjectPath, pathPattern, locale)
 		const keys = await readMessageFileKeys(messageFilePath)
 		if (keys) {
 			messageFileSnapshots.set(messageFilePath, keys)
+			ownedSnapshots.set(messageFilePath, keys)
 		}
+	}
+
+	return {
+		dispose: () => {
+			for (const [messageFilePath, snapshot] of ownedSnapshots) {
+				if (messageFileSnapshots.get(messageFilePath) === snapshot) {
+					messageFileSnapshots.delete(messageFilePath)
+				}
+			}
+		},
 	}
 }
 
-function getJsonPathPattern(
-	settings: Awaited<ReturnType<NonNullable<typeof state>["project"]["settings"]["get"]>>
-) {
+function getJsonPathPattern(settings: Awaited<ReturnType<InlangProject["settings"]["get"]>>) {
 	const pathPattern =
 		(settings as any)["plugin.inlang.json"]?.pathPattern ??
 		(settings as any)["plugin.inlang.messageFormat"]?.pathPattern

--- a/src/main.ts
+++ b/src/main.ts
@@ -131,10 +131,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 		})
 		installProjectRuntime(runtime)
 		context.subscriptions.push({ dispose: () => void disposeProjectRuntime() })
-		await activateInitialProjectSession({ context, workspaceFolder, fs: mappedFs })
 		if (state().projectsInWorkspace.length > 0) {
 			await registerGlobalViews({ context, workspaceFolder, fs: mappedFs })
 		}
+		await activateInitialProjectSession({ context, workspaceFolder, fs: mappedFs })
 
 		capture({
 			event: "IDE-EXTENSION activated",
@@ -171,7 +171,7 @@ async function activateInitialProjectSession(args: {
 
 		vscode.commands.executeCommand("setContext", "sherlock:hasProjectInWorkspace", true)
 		const result = await getProjectRuntime().replaceProject(selectedProjectPath)
-		if (result.status === "failed") throw result.error
+		if (result.status === "failed") handleError(result.error)
 
 		return
 	} else {

--- a/src/utilities/editor/editorView.test.ts
+++ b/src/utilities/editor/editorView.test.ts
@@ -1,4 +1,31 @@
-// TODO: implement tests
-import { test } from "vitest"
+import { describe, expect, it, vi } from "vitest"
+import { editorView } from "./editorView.js"
+import { saveProjectData } from "../../main.js"
 
-test.todo("TODO implement tests")
+vi.mock("vscode", () => ({}))
+vi.mock("../../configuration.js", () => ({ CONFIGURATION: { EVENTS: {} } }))
+vi.mock("../messages/msg.js", () => ({ msg: vi.fn() }))
+vi.mock("./helper/getUri.js", () => ({ getUri: vi.fn() }))
+vi.mock("../../main.js", () => ({
+	saveProject: vi.fn(),
+	saveProjectData: vi.fn(async () => undefined),
+}))
+
+describe("editorView", () => {
+	it("persists its owned project before session disposal", async () => {
+		const project = {}
+		const view = editorView({
+			extensionUri: {} as never,
+			initialBundleId: "welcome",
+			lease: {
+				path: "/workspace/project.inlang",
+				project,
+				isCurrent: () => false,
+			} as any,
+		})
+
+		await view.dispose({ persist: true })
+
+		expect(saveProjectData).toHaveBeenCalledWith(project, "/workspace/project.inlang")
+	})
+})

--- a/src/utilities/editor/editorView.ts
+++ b/src/utilities/editor/editorView.ts
@@ -3,16 +3,17 @@ import type { Disposable, WebviewPanel } from "vscode"
 
 import { getUri } from "./helper/getUri.js"
 import { getNonce } from "./helper/getNonce.js"
-import { state } from "../state.js"
 import { CONFIGURATION } from "../../configuration.js"
-import { getSelectedBundleByBundleIdOrAlias } from "../helper.js"
 import { msg } from "../messages/msg.js"
 import type { ChangeEventDetail } from "@inlang/editor-component"
 import { deleteVariant } from "./helper/deleteVariant.js"
 import { deleteBundleNested } from "./helper/deleteBundleNested.js"
 import { handleUpdateBundle } from "./helper/handleBundleUpdate.js"
 import { createMessage } from "./helper/createMessage.js"
-import { saveProject } from "../../main.js"
+import { saveProject, saveProjectData } from "../../main.js"
+import type { InlangProject } from "@inlang/sdk"
+import type { ActiveProjectLease } from "../project/projectRuntime.js"
+import { selectBundleById } from "../project/selectBundleById.js"
 
 // Same interface as before
 export interface UpdateBundleMessage {
@@ -33,19 +34,24 @@ export const EDITOR_PANEL_ID = "editorViewPanel"
  *
  * All your bundle/update logic remains the same.
  */
-export function editorView(args: { context: vscode.ExtensionContext; initialBundleId: string }) {
-	const { context, initialBundleId } = args
-	const extensionUri = context.extensionUri
+export function editorView(args: {
+	extensionUri: vscode.Uri
+	lease: ActiveProjectLease<InlangProject>
+	initialBundleId: string
+}) {
+	const { extensionUri, lease, initialBundleId } = args
 
 	let panel: WebviewPanel | undefined
 	let disposables: Disposable[] = []
 	let bundleId = initialBundleId
 	let pendingUpdate = Promise.resolve()
+	let disposed = false
 
 	/**
 	 * Opens a new panel if none is open, otherwise reveals the existing one.
 	 */
 	async function createOrShowPanel() {
+		if (disposed) return
 		if (panel) {
 			// If we already have a panel, reveal it
 			panel.reveal(vscode.ViewColumn.One)
@@ -66,9 +72,9 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		// Set up disposal
 		panel.onDidDispose(
 			() => {
-				void persistEdit()
-				dispose()
+				if (lease.isCurrent()) void persistEdit()
 				panel = undefined
+				dispose()
 			},
 			null,
 			disposables
@@ -78,12 +84,14 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		panel.onDidChangeViewState(
 			async (e) => {
 				if (e.webviewPanel.visible) {
+					const data = await lease.runTask(async () => ({
+						bundle: await selectBundleById(lease.project, bundleId),
+						settings: await lease.project.settings.get(),
+					}))
+					if (data.status !== "completed") return
 					panel?.webview.postMessage({
 						command: "change",
-						data: {
-							bundle: await getSelectedBundleByBundleIdOrAlias(bundleId),
-							settings: await state().project?.settings.get(),
-						},
+						data: data.value,
 					})
 				}
 			},
@@ -95,12 +103,14 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 		panel.webview.html = getHtmlForWebview(panel.webview)
 
 		// Set initial data
+		const initialData = await lease.runTask(async () => ({
+			bundle: await selectBundleById(lease.project, bundleId),
+			settings: await lease.project.settings.get(),
+		}))
+		if (initialData.status !== "completed") return
 		panel.webview.postMessage({
 			command: "change",
-			data: {
-				bundle: await getSelectedBundleByBundleIdOrAlias(bundleId),
-				settings: await state().project?.settings.get(),
-			},
+			data: initialData.value,
 		})
 
 		// Set up the same message listener logic
@@ -117,26 +127,21 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 
 			switch (command) {
 				case "create-message":
-					await createMessage({
-						db: state().project?.db,
-						message: message.message,
-					})
+					await lease.runTask(() =>
+						createMessage({ db: lease.project.db, message: message.message })
+					)
 
 					await updateView()
 					return
 				case "delete-variant":
-					await deleteVariant({
-						db: state().project?.db,
-						variantId: message.id,
-					})
+					await lease.runTask(() => deleteVariant({ db: lease.project.db, variantId: message.id }))
 
 					await updateView()
 					return
 				case "delete-bundle":
-					await deleteBundleNested({
-						db: state().project?.db,
-						bundleId: message.id,
-					})
+					await lease.runTask(() =>
+						deleteBundleNested({ db: lease.project.db, bundleId: message.id })
+					)
 
 					await updateView()
 					return
@@ -166,10 +171,9 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 
 	function queueUpdate(message: UpdateBundleMessage) {
 		pendingUpdate = pendingUpdate.then(() =>
-			handleUpdateBundle({
-				db: state().project?.db,
-				message,
-			})
+			lease
+				.runTask(() => handleUpdateBundle({ db: lease.project.db, message }))
+				.then(() => undefined)
 		)
 		return pendingUpdate
 	}
@@ -179,22 +183,25 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 	 */
 	async function updateView() {
 		await pendingUpdate
+		if (!lease.isCurrent()) return
 
 		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 		CONFIGURATION.EVENTS.ON_DID_EDITOR_VIEW_CHANGE.fire()
 
+		const data = await lease.runTask(async () => ({
+			bundle: await selectBundleById(lease.project, bundleId),
+			settings: await lease.project.settings.get(),
+		}))
+		if (data.status !== "completed") return
 		panel?.webview.postMessage({
 			command: "change",
-			data: {
-				bundle: await getSelectedBundleByBundleIdOrAlias(bundleId),
-				settings: await state().project?.settings.get(),
-			},
+			data: data.value,
 		})
 
 		const workspaceFolder = vscode.workspace.workspaceFolders![0]
 		if (workspaceFolder) {
 			try {
-				await saveProject()
+				await saveProject(lease)
 			} catch (error) {
 				console.error("Failed to save project", error)
 				msg(`Failed to save project. ${String(error)}`, "error")
@@ -204,13 +211,14 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 
 	async function persistEdit() {
 		await pendingUpdate
+		if (!lease.isCurrent()) return
 
 		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
 
 		const workspaceFolder = vscode.workspace.workspaceFolders![0]
 		if (workspaceFolder) {
 			try {
-				await saveProject()
+				await saveProject(lease)
 			} catch (error) {
 				console.error("Failed to save project", error)
 				msg(`Failed to save project. ${String(error)}`, "error")
@@ -294,7 +302,14 @@ export function editorView(args: { context: vscode.ExtensionContext; initialBund
 	/**
 	 * Dispose any event listeners or watchers
 	 */
-	function dispose() {
+	async function dispose(options: { persist?: boolean } = {}) {
+		if (disposed) return
+		disposed = true
+		await pendingUpdate
+		if (options.persist) await saveProjectData(lease.project, lease.path)
+		const currentPanel = panel
+		panel = undefined
+		currentPanel?.dispose()
 		while (disposables.length) {
 			const disposable = disposables.pop()
 			if (disposable) disposable.dispose()

--- a/src/utilities/errors/errors.test.ts
+++ b/src/utilities/errors/errors.test.ts
@@ -39,6 +39,23 @@ vi.mock("../state.js", () => ({
 	state: vi.fn(),
 }))
 
+vi.mock("../project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						runTask: async <T>(task: () => Promise<T>) => ({
+							status: "completed" as const,
+							value: await task(),
+						}),
+					}
+				: undefined
+		},
+	}),
+}))
+
 describe("error handling", () => {
 	beforeEach(() => {
 		// Clear all mocks and reset state to avoid leaks between tests

--- a/src/utilities/errors/errors.ts
+++ b/src/utilities/errors/errors.ts
@@ -1,6 +1,7 @@
 import * as vscode from "vscode"
-import { state } from "../state.js"
 import { CONFIGURATION } from "../../configuration.js"
+import type { InlangProject } from "@inlang/sdk"
+import { getProjectRuntime } from "../project/projectRuntime.js"
 
 export interface ErrorNode {
 	label: string
@@ -32,11 +33,15 @@ export function createErrorNode(error: Error | 0 | undefined): ErrorNode {
 }
 
 export async function createErrorNodes(): Promise<ErrorNode[]> {
-	const errors = ((await state().project.errors.get()) as Error[]) || []
-	if (state().project === undefined) {
+	const lease = getProjectRuntime<InlangProject>().activeProject()
+	if (!lease) {
 		// no project
 		return [createErrorNode(undefined)]
-	} else if (errors.length === 0) {
+	}
+	const result = await lease.runTask(() => lease.project.errors.get())
+	if (result.status !== "completed") return [createErrorNode(undefined)]
+	const errors = [...result.value]
+	if (errors.length === 0) {
 		// no errors
 		return [createErrorNode(0)]
 	}

--- a/src/utilities/fs/experimental/directMessageHandler.test.ts
+++ b/src/utilities/fs/experimental/directMessageHandler.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { setupDirectMessageWatcher } from "./directMessageHandler.js"
+
+const mocks = vi.hoisted(() => {
+	const callbacks: { change?: (uri: { fsPath: string }) => void } = {}
+	const watcher = {
+		onDidChange: vi.fn((callback) => {
+			callbacks.change = callback
+		}),
+		onDidCreate: vi.fn(),
+		onDidDelete: vi.fn(),
+		dispose: vi.fn(),
+	}
+	return {
+		callbacks,
+		watcher,
+		findFiles: vi.fn(),
+		readFile: vi.fn(async () => new TextEncoder().encode("{}")),
+		createFileSystemWatcher: vi.fn(() => watcher),
+		uiFire: vi.fn(),
+	}
+})
+
+vi.mock("vscode", () => ({
+	RelativePattern: vi.fn((workspaceFolder, pattern) => ({ workspaceFolder, pattern })),
+	workspace: {
+		createFileSystemWatcher: mocks.createFileSystemWatcher,
+		findFiles: mocks.findFiles,
+		fs: { readFile: mocks.readFile },
+	},
+}))
+
+vi.mock("../../../configuration.js", () => ({
+	CONFIGURATION: {
+		EVENTS: { ON_DID_EDIT_MESSAGE: { fire: mocks.uiFire } },
+	},
+}))
+
+vi.mock("../../utils.js", () => ({ handleError: vi.fn() }))
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+function createSession(
+	runTask = vi.fn(async <T>(task: () => Promise<T>) => ({
+		status: "completed" as const,
+		value: await task(),
+	}))
+) {
+	return {
+		path: "/workspace/project.inlang",
+		project: {},
+		runTask,
+	} as any
+}
+
+describe("setupDirectMessageWatcher", () => {
+	afterEach(() => {
+		vi.useRealTimers()
+		vi.clearAllMocks()
+		mocks.callbacks.change = undefined
+	})
+
+	it("waits for the initial snapshot scan and owns exactly one watcher", async () => {
+		const scan = deferred<Array<{ fsPath: string }>>()
+		mocks.findFiles.mockReturnValueOnce(scan.promise)
+		const subscriptions: Array<{ dispose(): unknown }> = []
+
+		const setup = setupDirectMessageWatcher({
+			subscriptions,
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as any,
+			session: createSession(),
+		})
+		let settled = false
+		void setup.then(() => {
+			settled = true
+		})
+		await Promise.resolve()
+
+		expect(settled).toBe(false)
+		expect(mocks.createFileSystemWatcher).toHaveBeenCalledTimes(1)
+		expect(mocks.findFiles).toHaveBeenCalledTimes(1)
+
+		scan.resolve([])
+		await setup
+		expect(subscriptions).toHaveLength(1)
+
+		await subscriptions[0]!.dispose()
+		expect(mocks.watcher.dispose).toHaveBeenCalledTimes(1)
+	})
+
+	it("stops the watcher immediately and waits for a running callback", async () => {
+		vi.useFakeTimers()
+		mocks.findFiles.mockResolvedValueOnce([])
+		const callback = deferred<{ status: "completed"; value: false }>()
+		const runTask = vi
+			.fn()
+			.mockImplementationOnce(async <T>(task: () => Promise<T>) => ({
+				status: "completed" as const,
+				value: await task(),
+			}))
+			.mockImplementationOnce(() => callback.promise)
+		const subscriptions: Array<{ dispose(): unknown }> = []
+		await setupDirectMessageWatcher({
+			subscriptions,
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as any,
+			session: createSession(runTask),
+		})
+
+		mocks.callbacks.change?.({ fsPath: "/workspace/messages/en.json" })
+		await vi.advanceTimersByTimeAsync(150)
+		expect(runTask).toHaveBeenCalledTimes(2)
+
+		const disposal = Promise.resolve(subscriptions[0]!.dispose())
+		let settled = false
+		void disposal.then(() => {
+			settled = true
+		})
+		await Promise.resolve()
+
+		expect(mocks.watcher.dispose).toHaveBeenCalledTimes(1)
+		expect(settled).toBe(false)
+
+		callback.resolve({ status: "completed", value: false })
+		await disposal
+		expect(settled).toBe(true)
+	})
+
+	it("does not refresh the UI when file work finishes on an inactive session", async () => {
+		vi.useFakeTimers()
+		mocks.findFiles.mockResolvedValueOnce([])
+		const importFiles = vi.fn(async () => undefined)
+		const runTask = vi
+			.fn()
+			.mockImplementationOnce(async <T>(task: () => Promise<T>) => ({
+				status: "completed" as const,
+				value: await task(),
+			}))
+			.mockImplementationOnce(async <T>(task: () => Promise<T>) => {
+				await task()
+				return { status: "inactive" as const }
+			})
+		const session = createSession(runTask)
+		session.project = {
+			db: {},
+			plugins: { get: vi.fn(async () => [{ key: "json" }]) },
+			importFiles,
+		}
+		await setupDirectMessageWatcher({
+			subscriptions: [],
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as any,
+			session,
+		})
+
+		mocks.callbacks.change?.({ fsPath: "/workspace/messages/en.json" })
+		await vi.advanceTimersByTimeAsync(150)
+		await vi.waitFor(() => expect(importFiles).toHaveBeenCalledTimes(1))
+
+		expect(mocks.uiFire).not.toHaveBeenCalled()
+	})
+})

--- a/src/utilities/fs/experimental/directMessageHandler.ts
+++ b/src/utilities/fs/experimental/directMessageHandler.ts
@@ -9,22 +9,18 @@
 
 import * as vscode from "vscode"
 import * as path from "path"
-import { state } from "../../state.js"
 import { CONFIGURATION } from "../../../configuration.js"
 import { handleError } from "../../utils.js"
 import * as crypto from "crypto"
-import type { InlangDatabaseSchema } from "@inlang/sdk"
+import type { InlangDatabaseSchema, InlangProject } from "@inlang/sdk"
 import type { Kysely } from "kysely"
+import {
+	deactivateBeforeClose,
+	type Disposable,
+	type ProjectSession,
+} from "../../project/projectSession.js"
 
-// Store file hashes to detect real changes
-const fileHashes = new Map<string, string>()
-// Store message keys by file path to track deleted keys
-const fileMessageKeys = new Map<string, Set<string>>()
 const DEBOUNCE_MS = 150 // Reduced debounce time for faster updates
-const processingFiles = new Set<string>() // Prevent concurrent processing of the same file
-const lastFileUpdateTime = new Map<string, number>() // Track when files were last processed
-let isInEventLoop = false // Global flag to detect event loops
-let lastUIUpdateTime = 0 // Track when we last fired UI update events
 const MIN_UI_UPDATE_INTERVAL_MS = 300 // Minimum time between UI updates to prevent UI lag
 
 // Optimized file hash function that avoids full content hashing for large files
@@ -51,49 +47,37 @@ async function extractMessageKeys(uri: vscode.Uri): Promise<Set<string>> {
 	}
 }
 
-// Throttled UI update function to prevent UI lag from too many updates
-function throttledUIUpdate() {
-	const now = Date.now()
-	if (now - lastUIUpdateTime < MIN_UI_UPDATE_INTERVAL_MS) {
-		// Don't update if it's too soon after the last update
-		return false
-	}
-
-	// Update the last update time
-	lastUIUpdateTime = now
-
-	// Set the event loop flag
-	isInEventLoop = true
-
-	// Fire the event
-	CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
-
-	// Reset the flag after a short delay
-	setTimeout(() => {
-		isInEventLoop = false
-	}, 500) // Shorter timeout for better responsiveness
-
-	return true
-}
-
 // Optimized debounce function to prevent rapid-fire events
 function debounce<T extends (...args: any[]) => Promise<void>>(
 	func: T,
 	wait: number
-): (...args: Parameters<T>) => void {
+): ((...args: Parameters<T>) => void) & { cancel(): void; settled(): Promise<void> } {
 	let timeout: NodeJS.Timeout | null = null
+	const running = new Set<Promise<void>>()
 
-	return function (...args: Parameters<T>) {
+	const debounced = function (...args: Parameters<T>) {
 		if (timeout) {
 			clearTimeout(timeout)
 		}
 		timeout = setTimeout(() => {
-			func(...args).catch((error) => {
-				console.error("Error in debounced function:", error)
-			})
+			const execution = func(...args)
+			running.add(execution)
+			execution
+				.catch((error) => {
+					console.error("Error in debounced function:", error)
+				})
+				.finally(() => running.delete(execution))
 			timeout = null
 		}, wait)
 	}
+	debounced.cancel = () => {
+		if (timeout) clearTimeout(timeout)
+		timeout = null
+	}
+	debounced.settled = async () => {
+		await Promise.allSettled([...running])
+	}
+	return debounced
 }
 
 // Helper function to delete message variants by locale
@@ -147,11 +131,33 @@ async function deleteMessageVariantsByLocale(
 /**
  * Set up a watcher for message JSON files specifically
  */
-export async function setupDirectMessageWatcher(args: {
-	context: vscode.ExtensionContext
+export function setupDirectMessageWatcher(args: {
+	subscriptions: Disposable[]
 	workspaceFolder: vscode.WorkspaceFolder
-}) {
+	session: ProjectSession<InlangProject>
+}): Promise<void> {
 	try {
+		const fileHashes = new Map<string, string>()
+		const fileMessageKeys = new Map<string, Set<string>>()
+		const processingFiles = new Set<string>()
+		const lastFileUpdateTime = new Map<string, number>()
+		let isInEventLoop = false
+		let lastUIUpdateTime = 0
+		let eventLoopReset: NodeJS.Timeout | undefined
+
+		const throttledUIUpdate = () => {
+			const now = Date.now()
+			if (now - lastUIUpdateTime < MIN_UI_UPDATE_INTERVAL_MS) return false
+			lastUIUpdateTime = now
+			isInEventLoop = true
+			CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire()
+			if (eventLoopReset) clearTimeout(eventLoopReset)
+			eventLoopReset = setTimeout(() => {
+				isInEventLoop = false
+			}, 500)
+			return true
+		}
+
 		console.log("Setting up direct message watcher...")
 
 		// Create a watcher for JSON files in any 'messages' directory
@@ -160,15 +166,20 @@ export async function setupDirectMessageWatcher(args: {
 
 		console.log("Created message watcher for pattern: **/messages/*.json")
 
-		const messageFiles = await vscode.workspace.findFiles(messagePattern)
-		for (const uri of messageFiles) {
-			const filePath = uri.fsPath
-			fileHashes.set(filePath, await getFileHash(uri))
-			fileMessageKeys.set(filePath, await extractMessageKeys(uri))
-		}
+		const initialization = args.session
+			.runTask(async () => {
+				const messageFiles = await vscode.workspace.findFiles(messagePattern)
+				for (const uri of messageFiles) {
+					const filePath = uri.fsPath
+					fileHashes.set(filePath, await getFileHash(uri))
+					fileMessageKeys.set(filePath, await extractMessageKeys(uri))
+				}
+			})
+			.then(() => undefined)
+			.catch(handleError)
 
 		// Create debounced handler for message file events
-		const debouncedHandleMessageEvent = debounce(async (uri: vscode.Uri, eventType: string) => {
+		const handleMessageEvent = async (uri: vscode.Uri, eventType: string) => {
 			const filePath = uri.fsPath
 
 			// Skip if already processing
@@ -211,7 +222,7 @@ export async function setupDirectMessageWatcher(args: {
 				console.log(`Processing message file ${eventType} event: ${filePath}`)
 
 				// Get the current project
-				const currentProject = state().project
+				const currentProject = args.session.project
 				if (!currentProject) {
 					console.log("No current project found")
 					processingFiles.delete(filePath)
@@ -293,23 +304,20 @@ export async function setupDirectMessageWatcher(args: {
 								}
 							}
 
-							// If deletions happened, refresh the UI to reflect them
+							// Keep deletion processing observable for diagnostics.
 							if (madeChanges) {
-								console.log(`Made changes due to deleted keys, refreshing UI...`)
-
-								// Update UI with throttling for better performance
-								throttledUIUpdate()
+								console.log(`Made changes due to deleted keys`)
 							}
 						}
 
-						console.log(`External change detected, updating UI for locale: ${locale}`)
-						throttledUIUpdate()
+						console.log(`External change detected for locale: ${locale}`)
 
 						// Record this update time
 						lastFileUpdateTime.set(filePath, Date.now())
 					} catch (error) {
 						console.error(`Error importing message file:`, error)
 						handleError(error)
+						return false
 					}
 				} else {
 					console.log(`File deleted: ${filePath} - handling deletion for locale ${locale}`)
@@ -334,23 +342,25 @@ export async function setupDirectMessageWatcher(args: {
 						// Clear all message keys for deleted files
 						fileMessageKeys.delete(filePath)
 
-						// If deletions happened, refresh the UI to reflect them
+						// Keep deletion processing observable for diagnostics.
 						if (madeChanges) {
-							// Force update UI with throttling
-							throttledUIUpdate()
+							console.log(`Made changes due to deleted locale ${locale}`)
 						}
 					}
-
-					// Only update UI for genuine deletions with throttling
-					throttledUIUpdate()
 
 					// Record this update
 					lastFileUpdateTime.set(filePath, Date.now())
 				}
+				return true
 			} finally {
 				// Always remove from processing list
 				processingFiles.delete(filePath)
 			}
+		}
+
+		const debouncedHandleMessageEvent = debounce(async (uri: vscode.Uri, eventType: string) => {
+			const result = await args.session.runTask(() => handleMessageEvent(uri, eventType))
+			if (result.status === "completed" && result.value) throttledUIUpdate()
 		}, DEBOUNCE_MS)
 
 		// Attach event handlers
@@ -359,11 +369,26 @@ export async function setupDirectMessageWatcher(args: {
 		watcher.onDidDelete(async (e) => debouncedHandleMessageEvent(e, "Deleted"))
 
 		// Track and register watcher
-		args.context.subscriptions.push(watcher)
+		args.subscriptions.push(
+			deactivateBeforeClose({
+				dispose: async () => {
+					debouncedHandleMessageEvent.cancel()
+					if (eventLoopReset) clearTimeout(eventLoopReset)
+					watcher.dispose()
+					await debouncedHandleMessageEvent.settled()
+					fileHashes.clear()
+					fileMessageKeys.clear()
+					processingFiles.clear()
+					lastFileUpdateTime.clear()
+				},
+			})
+		)
 
 		console.log("Direct message watcher setup complete")
+		return initialization
 	} catch (error) {
 		console.error("Error setting up direct message watcher:", error)
 		handleError(error)
+		return Promise.resolve()
 	}
 }

--- a/src/utilities/helper.ts
+++ b/src/utilities/helper.ts
@@ -1,17 +1,10 @@
-import { selectBundleNested, type IdeExtensionConfig } from "@inlang/sdk"
+import { type IdeExtensionConfig, type InlangProject } from "@inlang/sdk"
 import { state } from "./state.js"
 
-export const getExtensionApi = async (): Promise<IdeExtensionConfig | undefined> =>
-	(await state().project.plugins.get()).find((plugin) => plugin?.meta?.["app.inlang.ideExtension"])
+export const getExtensionApi = async (
+	project: InlangProject | undefined = state().project
+): Promise<IdeExtensionConfig | undefined> => {
+	if (!project) return undefined
+	return (await project.plugins.get()).find((plugin) => plugin?.meta?.["app.inlang.ideExtension"])
 		?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
-
-/**
- *
- * @deprecated
- * Not needed anymore but left in to reduce refactoring https://github.com/opral/monorepo/pull/3137
- */
-export const getSelectedBundleByBundleIdOrAlias = async (bundleIdOrAlias: string) => {
-	return await selectBundleNested(state().project.db)
-		.where("bundle.id", "=", bundleIdOrAlias)
-		.executeTakeFirst()
 }

--- a/src/utilities/lint-rules/lintRules.ts
+++ b/src/utilities/lint-rules/lintRules.ts
@@ -1,6 +1,7 @@
 import { state } from "../state.js"
 import * as vscode from "vscode"
-import { getSelectedBundleByBundleIdOrAlias } from "../helper.js"
+import type { InlangProject } from "@inlang/sdk"
+import { selectBundleById } from "../project/selectBundleById.js"
 
 export interface LintResult {
 	bundleId: string
@@ -14,10 +15,14 @@ export interface LintResult {
 /**
  * Lint rule: Checks if any message in a bundle is missing a translation (empty variants).
  */
-export const missingMessage = async (bundleId: string): Promise<LintResult[]> => {
-	const locales = (await state().project.settings.get()).locales
+export const missingMessage = async (
+	bundleId: string,
+	project: InlangProject | undefined = state().project
+): Promise<LintResult[]> => {
+	if (!project) return []
+	const locales = (await project.settings.get()).locales
 
-	const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+	const bundle = await selectBundleById(project, bundleId)
 
 	if (!bundle) return []
 
@@ -40,11 +45,13 @@ export const missingMessage = async (bundleId: string): Promise<LintResult[]> =>
  * Lint rule: Checks if any message in a bundle is missing the message with the baseLocale
  */
 export const bundleWithoutMessageWithBaseLocale = async (
-	bundleId: string
+	bundleId: string,
+	project: InlangProject | undefined = state().project
 ): Promise<LintResult[]> => {
-	const baseLocale = (await state().project.settings.get()).baseLocale
+	if (!project) return []
+	const baseLocale = (await project.settings.get()).baseLocale
 
-	const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+	const bundle = await selectBundleById(project, bundleId)
 
 	if (!bundle) return []
 
@@ -64,8 +71,12 @@ export const bundleWithoutMessageWithBaseLocale = async (
 /**
  * Lint rule: Checks if any variant in a bundle has an empty pattern.
  */
-export const variantWithEmptyPattern = async (bundleId: string): Promise<LintResult[]> => {
-	const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+export const variantWithEmptyPattern = async (
+	bundleId: string,
+	project: InlangProject | undefined = state().project
+): Promise<LintResult[]> => {
+	if (!project) return []
+	const bundle = await selectBundleById(project, bundleId)
 
 	if (!bundle) return []
 
@@ -85,7 +96,10 @@ export const variantWithEmptyPattern = async (bundleId: string): Promise<LintRes
 /**
  * Utility function to check if the bundle id is a valid JS identifier.
  */
-export const invalidJSIdentifier = async (bundleId: string): Promise<LintResult[]> => {
+export const invalidJSIdentifier = async (
+	bundleId: string,
+	project: InlangProject | undefined = state().project
+): Promise<LintResult[]> => {
 	const isValidJsIdentifier = (id: string) => {
 		try {
 			new Function(`var ${id};`)
@@ -95,7 +109,8 @@ export const invalidJSIdentifier = async (bundleId: string): Promise<LintResult[
 		}
 	}
 
-	const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+	if (!project) return []
+	const bundle = await selectBundleById(project, bundleId)
 
 	if (!bundle) return []
 
@@ -115,8 +130,12 @@ export const invalidJSIdentifier = async (bundleId: string): Promise<LintResult[
 /**
  * Utility function to find identical patterns in messages.
  */
-export const identicalPattern = async (bundleId: string): Promise<LintResult[]> => {
-	const bundle = await getSelectedBundleByBundleIdOrAlias(bundleId)
+export const identicalPattern = async (
+	bundleId: string,
+	project: InlangProject | undefined = state().project
+): Promise<LintResult[]> => {
+	if (!project) return []
+	const bundle = await selectBundleById(project, bundleId)
 
 	if (!bundle) return []
 

--- a/src/utilities/locale/getPreviewLocale.ts
+++ b/src/utilities/locale/getPreviewLocale.ts
@@ -1,8 +1,10 @@
 import { state } from "../state.js"
 import { getSetting } from "../settings/index.js"
+import type { InlangProject } from "@inlang/sdk"
 
-export async function getPreviewLocale() {
-	const settings = await state().project.settings.get()
+export async function getPreviewLocale(project: InlangProject | undefined = state().project) {
+	if (!project) return undefined
+	const settings = await project.settings.get()
 	const baseLocale = settings.baseLocale
 	const previewLanguageTag = ((await getSetting("previewLanguageTag")) as string) || baseLocale
 

--- a/src/utilities/messages/messages.test.ts
+++ b/src/utilities/messages/messages.test.ts
@@ -5,9 +5,18 @@ import {
 	createMessageHtml,
 	createNoMessagesFoundHtml,
 	createMessagesLoadingHtml,
+	createMessageWebviewProvider,
 	getHtml,
 	getTranslationsTableHtml,
 } from "./messages.js"
+import { CONFIGURATION } from "../../configuration.js"
+
+const pollSubscribe = vi.hoisted(() => vi.fn())
+
+const completedTask = async <T>(task: () => Promise<T>) => ({
+	status: "completed" as const,
+	value: await task(),
+})
 
 // Mocking vscode module and state module
 vi.mock("vscode", () => ({
@@ -31,7 +40,16 @@ vi.mock("vscode", () => ({
 		asWebviewUri: vi.fn(),
 		cspSource: "cspSource",
 	})),
-	EventEmitter: vi.fn(),
+	EventEmitter: class {
+		listeners = new Set<(value: unknown) => void>()
+		event = (listener: (value: unknown) => void) => {
+			this.listeners.add(listener)
+			return { dispose: () => this.listeners.delete(listener) }
+		}
+		fire = (value: unknown) => {
+			for (const listener of this.listeners) listener(value)
+		}
+	},
 	CodeActionKind: {
 		QuickFix: vi.fn(),
 	},
@@ -48,6 +66,10 @@ vi.mock("vscode", () => ({
 
 vi.mock("../state.js", () => ({
 	state: vi.fn(),
+}))
+
+vi.mock("../polling/pollQuery.js", () => ({
+	pollQuery: vi.fn(() => ({ subscribe: pollSubscribe })),
 }))
 
 describe("Message Webview Provider Tests", () => {
@@ -239,6 +261,191 @@ describe("Message Webview Provider Tests", () => {
 		expect(html).toContain("Loading messages...")
 	})
 
+	it("replaces polling when reload creates a new project at the same path", async () => {
+		const firstSubscription = { unsubscribe: vi.fn(async () => undefined) }
+		const secondSubscription = { unsubscribe: vi.fn(async () => undefined) }
+		pollSubscribe.mockReturnValueOnce(firstSubscription).mockReturnValueOnce(secondSubscription)
+		const firstProject = { db: {}, plugins: { get: vi.fn(async () => []) } }
+		const secondProject = { db: {}, plugins: { get: vi.fn(async () => []) } }
+		const provider = createMessageWebviewProvider({
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as vscode.WorkspaceFolder,
+			context: {
+				subscriptions: [],
+				extensionUri: { fsPath: "/extension" },
+			} as unknown as vscode.ExtensionContext,
+		})
+		const firstBinding = provider.bindProject({
+			path: "/workspace/project.inlang",
+			project: firstProject,
+			runTask: completedTask,
+		} as any)
+		provider.resolveWebviewView(
+			{
+				onDidDispose: vi.fn(),
+				webview: {
+					onDidReceiveMessage: vi.fn(),
+					asWebviewUri: vi.fn((uri) => uri),
+					cspSource: "test-csp",
+					options: {},
+					html: "",
+				},
+			} as unknown as vscode.WebviewView,
+			{} as never,
+			{} as never
+		)
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(1))
+
+		provider.bindProject({
+			path: "/workspace/project.inlang",
+			project: secondProject,
+			runTask: completedTask,
+		} as any)
+		await Promise.resolve()
+		expect(pollSubscribe).toHaveBeenCalledTimes(1)
+		CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire(undefined)
+		await firstBinding.dispose()
+
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(2))
+		expect(firstSubscription.unsubscribe).toHaveBeenCalledTimes(1)
+		expect(secondSubscription.unsubscribe).not.toHaveBeenCalled()
+	})
+
+	it("registers global listeners once and suspends polling while the view is disposed", async () => {
+		const firstSubscription = { unsubscribe: vi.fn(async () => undefined) }
+		const secondSubscription = { unsubscribe: vi.fn(async () => undefined) }
+		pollSubscribe.mockReturnValueOnce(firstSubscription).mockReturnValueOnce(secondSubscription)
+		const provider = createMessageWebviewProvider({
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as vscode.WorkspaceFolder,
+			context: {
+				subscriptions: [],
+				extensionUri: { fsPath: "/extension" },
+			} as unknown as vscode.ExtensionContext,
+		})
+		provider.bindProject({
+			path: "/workspace/project.inlang",
+			project: { db: {}, plugins: { get: vi.fn(async () => []) } },
+			runTask: completedTask,
+		} as any)
+		let disposeFirstView!: () => void
+		const createView = (captureDispose?: (callback: () => void) => void) =>
+			({
+				onDidDispose: vi.fn((callback) => captureDispose?.(callback)),
+				webview: {
+					onDidReceiveMessage: vi.fn(),
+					asWebviewUri: vi.fn((uri) => uri),
+					cspSource: "test-csp",
+					options: {},
+					html: "",
+				},
+			}) as unknown as vscode.WebviewView
+
+		provider.resolveWebviewView(
+			createView((callback) => (disposeFirstView = callback)),
+			{} as never,
+			{} as never
+		)
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(1))
+		disposeFirstView()
+		await vi.waitFor(() => expect(firstSubscription.unsubscribe).toHaveBeenCalledTimes(1))
+
+		provider.resolveWebviewView(createView(), {} as never, {} as never)
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(2))
+		expect(vscode.window.onDidChangeActiveTextEditor).toHaveBeenCalledTimes(1)
+		expect(vscode.workspace.onDidChangeTextDocument).toHaveBeenCalledTimes(1)
+		expect(vscode.workspace.onDidChangeConfiguration).toHaveBeenCalledTimes(1)
+	})
+
+	it("does not let late disposal of an old view tear down its replacement", async () => {
+		const subscription = { unsubscribe: vi.fn(async () => undefined) }
+		pollSubscribe.mockReturnValueOnce(subscription)
+		const provider = createMessageWebviewProvider({
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as vscode.WorkspaceFolder,
+			context: {
+				subscriptions: [],
+				extensionUri: { fsPath: "/extension" },
+			} as unknown as vscode.ExtensionContext,
+		})
+		provider.bindProject({
+			path: "/workspace/project.inlang",
+			project: { db: {}, plugins: { get: vi.fn(async () => []) } },
+			runTask: completedTask,
+		} as any)
+		let disposeFirstView!: () => void
+		let disposeSecondView!: () => void
+		const createView = (captureDispose: (callback: () => void) => void) =>
+			({
+				onDidDispose: vi.fn(captureDispose),
+				webview: {
+					onDidReceiveMessage: vi.fn(),
+					asWebviewUri: vi.fn((uri) => uri),
+					cspSource: "test-csp",
+					options: {},
+					html: "",
+				},
+			}) as unknown as vscode.WebviewView
+
+		provider.resolveWebviewView(
+			createView((callback) => (disposeFirstView = callback)),
+			{} as never,
+			{} as never
+		)
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(1))
+		provider.resolveWebviewView(
+			createView((callback) => (disposeSecondView = callback)),
+			{} as never,
+			{} as never
+		)
+
+		disposeFirstView()
+		await Promise.resolve()
+		expect(subscription.unsubscribe).not.toHaveBeenCalled()
+
+		disposeSecondView()
+		await vi.waitFor(() => expect(subscription.unsubscribe).toHaveBeenCalledTimes(1))
+	})
+
+	it("stops polling when VS Code cancels webview resolution", async () => {
+		const subscription = { unsubscribe: vi.fn(async () => undefined) }
+		pollSubscribe.mockReturnValueOnce(subscription)
+		const provider = createMessageWebviewProvider({
+			workspaceFolder: { uri: { fsPath: "/workspace" } } as vscode.WorkspaceFolder,
+			context: {
+				subscriptions: [],
+				extensionUri: { fsPath: "/extension" },
+			} as unknown as vscode.ExtensionContext,
+		})
+		provider.bindProject({
+			path: "/workspace/project.inlang",
+			project: { db: {}, plugins: { get: vi.fn(async () => []) } },
+			runTask: completedTask,
+		} as any)
+		let cancel!: () => void
+		provider.resolveWebviewView(
+			{
+				onDidDispose: vi.fn(),
+				webview: {
+					onDidReceiveMessage: vi.fn(() => ({ dispose: vi.fn() })),
+					asWebviewUri: vi.fn((uri) => uri),
+					cspSource: "test-csp",
+					options: {},
+					html: "",
+				},
+			} as unknown as vscode.WebviewView,
+			{} as never,
+			{
+				onCancellationRequested: vi.fn((callback) => {
+					cancel = callback
+					return { dispose: vi.fn() }
+				}),
+			} as unknown as vscode.CancellationToken
+		)
+		await vi.waitFor(() => expect(pollSubscribe).toHaveBeenCalledTimes(1))
+
+		cancel()
+
+		await vi.waitFor(() => expect(subscription.unsubscribe).toHaveBeenCalledTimes(1))
+	})
+
 	it("should create the complete webview HTML", () => {
 		// Mocking the context and webview
 		const context = {
@@ -252,6 +459,7 @@ describe("Message Webview Provider Tests", () => {
 		const html = getHtml({
 			mainContent: "<div>Main Content</div>",
 			webview,
+			extensionUri: context.extensionUri,
 		})
 
 		// Validating that the webview HTML contains the expected content

--- a/src/utilities/messages/messages.ts
+++ b/src/utilities/messages/messages.ts
@@ -13,10 +13,13 @@ import {
 } from "@inlang/sdk"
 import { logger } from "../logger.js"
 import { pollQuery } from "../polling/pollQuery.js"
+import type { Disposable, ProjectSession } from "../project/projectSession.js"
 
-// Store previous subscription state
-let subscription: { unsubscribe: () => void } | undefined
-let previousBundles: BundleNested[] | undefined
+type MessageProjectSession = ProjectSession<InlangProject>
+
+export type MessageViewController = vscode.WebviewViewProvider & {
+	bindProject(session: MessageProjectSession): Disposable
+}
 
 const getSafeState =
 	"safeState" in stateModule && typeof (stateModule as any).safeState === "function"
@@ -26,13 +29,18 @@ const getSafeState =
 export function createMessageWebviewProvider(args: {
 	workspaceFolder: vscode.WorkspaceFolder
 	context: vscode.ExtensionContext
-}) {
+}): MessageViewController {
 	let bundles: BundleNested[] | undefined
 	let isLoading = true
-	let subscribedToProjectPath = ""
+	let subscription: { unsubscribe: () => Promise<void> } | undefined
+	let subscribedSession: MessageProjectSession | undefined
+	let subscriptionTransition = Promise.resolve()
+	let previousBundles: BundleNested[] | undefined
+	let boundSession: MessageProjectSession | undefined
 	let activeFileContent: string | undefined
 	let lastDocumentUri: string | undefined
 	let debounceTimer: NodeJS.Timeout | undefined
+	let webviewView: vscode.WebviewView | undefined
 	// Add a flag to prevent event loops
 	let isProcessingUpdate = false
 
@@ -49,53 +57,63 @@ export function createMessageWebviewProvider(args: {
 	 *   projectPath: projectRoot,
 	 * })
 	 */
-	const subscribeToProjectBundles = async (args: {
-		project: InlangProject
-		projectPath: string
-		force?: boolean
-	}) => {
-		const shouldReuseExistingSubscription =
-			!args.force && subscription && subscribedToProjectPath === args.projectPath
-
-		if (shouldReuseExistingSubscription) {
-			return
-		}
-
-		if (subscription) {
-			subscription.unsubscribe()
-			subscription = undefined
-		}
-
-		subscribedToProjectPath = args.projectPath
-		bundles = undefined
-		previousBundles = undefined
-		isLoading = true
-		void updateWebviewContent()
-
-		const poller = pollQuery(async () => {
-			const query = selectBundleNested(args.project.db)
-			return (await query.execute()) as BundleNested[]
-		})
-
-		subscription = poller.subscribe((result) => {
-			const nextBundles = result as BundleNested[]
-			if (!isEqual(previousBundles, nextBundles)) {
-				logger.debug("Bundles updated via polling", {
-					count: nextBundles.length,
-				})
-				previousBundles = [...nextBundles]
-				bundles = nextBundles
-				isLoading = false
-				throttledUpdateWebviewContent()
-			}
-		})
+	const queueSubscriptionTransition = <T>(transition: () => Promise<T>) => {
+		const result = subscriptionTransition.then(transition)
+		subscriptionTransition = result.then(
+			() => undefined,
+			() => undefined
+		)
+		return result
 	}
+
+	const subscribeToProjectBundles = (args: { session: MessageProjectSession; force?: boolean }) =>
+		queueSubscriptionTransition(async () => {
+			if (boundSession !== args.session || !webviewView) return
+			const shouldReuseExistingSubscription =
+				!args.force && subscription && subscribedSession === args.session
+
+			if (shouldReuseExistingSubscription) return
+
+			const previousSubscription = subscription
+			subscription = undefined
+			subscribedSession = undefined
+			await previousSubscription?.unsubscribe()
+
+			if (boundSession !== args.session || !webviewView) return
+
+			bundles = undefined
+			previousBundles = undefined
+			isLoading = true
+			void updateWebviewContent()
+
+			const poller = pollQuery(async () => {
+				const result = await args.session.runTask(async () => {
+					const query = selectBundleNested(args.session.project.db)
+					return (await query.execute()) as BundleNested[]
+				})
+				return result.status === "completed" ? result.value : []
+			})
+
+			subscribedSession = args.session
+			subscription = poller.subscribe((result) => {
+				if (boundSession !== args.session || subscribedSession !== args.session) return
+				const nextBundles = result as BundleNested[]
+				if (!isEqual(previousBundles, nextBundles)) {
+					logger.debug("Bundles updated via polling", {
+						count: nextBundles.length,
+					})
+					previousBundles = [...nextBundles]
+					bundles = nextBundles
+					isLoading = false
+					throttledUpdateWebviewContent()
+				}
+			})
+		})
 
 	const updateMessages = async () => {
 		logger.debug("Message view update requested")
-		const currentState = getSafeState()
-		const project = currentState?.project as InlangProject | undefined
-		if (!project) {
+		const session = boundSession
+		if (!session || !webviewView) {
 			logger.warn("Skipping message update because no project is loaded")
 			isLoading = true
 			bundles = undefined
@@ -103,26 +121,10 @@ export function createMessageWebviewProvider(args: {
 			return
 		}
 
-		// Ensure we are only subscribing when the project actually changes
-		const selectedProjectPath = currentState?.selectedProjectPath
-		if (subscribedToProjectPath !== selectedProjectPath) {
-			logger.debug("Subscribing to new project", {
-				selectedProjectPath,
-			})
-			await subscribeToProjectBundles({
-				project,
-				projectPath: selectedProjectPath ?? "",
-			})
+		if (!subscription || subscribedSession !== session) {
+			await subscribeToProjectBundles({ session })
 		} else {
-			// Ensure a subscription exists even if the project path did not change
-			if (!subscription && selectedProjectPath) {
-				await subscribeToProjectBundles({
-					project,
-					projectPath: selectedProjectPath,
-				})
-			} else {
-				throttledUpdateWebviewContent()
-			}
+			throttledUpdateWebviewContent()
 		}
 	}
 
@@ -136,24 +138,17 @@ export function createMessageWebviewProvider(args: {
 
 		isProcessingUpdate = true
 		logger.debug("Forcing immediate message refresh")
-		const project = getSafeState()?.project as InlangProject | undefined
-		if (!project) {
+		const session = boundSession
+		if (!session) {
 			logger.warn("Cannot force refresh when no project is loaded")
 			isProcessingUpdate = false
 			return
 		}
 
 		try {
-			const activeProjectPath = subscribedToProjectPath || ""
-			if (!activeProjectPath) {
-				logger.warn("Skipping force refresh because no project path is active")
-				return
-			}
-
 			logger.debug("Forced refresh requested via polling")
 			await subscribeToProjectBundles({
-				project,
-				projectPath: activeProjectPath,
+				session,
 				force: true,
 			})
 		} catch (error) {
@@ -194,41 +189,43 @@ export function createMessageWebviewProvider(args: {
 	const updateWebviewContent = async () => {
 		const activeEditor = vscode.window.activeTextEditor
 		const fileContent = activeEditor ? activeEditor.document.getText() : ""
-		const activeProject = getSafeState()?.project
-		if (!activeProject) {
+		const session = boundSession
+		if (!session || !webviewView) {
 			logger.warn("Cannot update webview because project is undefined")
 			bundles = undefined
 			isLoading = true
 			return
 		}
 
-		const ideExtension = (await activeProject.plugins.get()).find(
-			(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
-		)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
-		const messageReferenceMatchers = ideExtension?.messageReferenceMatchers
+		const rendered = await session.runTask(async () => {
+			const activeProject = session.project
+			const ideExtension = (await activeProject.plugins.get()).find(
+				(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
+			)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
+			const messageReferenceMatchers = ideExtension?.messageReferenceMatchers
 
-		const matchedBundles = (
-			await Promise.all(
-				(messageReferenceMatchers ?? []).map(async (matcher) => {
-					return matcher({ documentText: fileContent })
+			const matchedBundles = (
+				await Promise.all(
+					(messageReferenceMatchers ?? []).map(async (matcher) => {
+						return matcher({ documentText: fileContent })
+					})
+				)
+			).flat()
+
+			const highlightedBundles = await Promise.all(
+				matchedBundles.map(async (bundle) => {
+					// @ts-ignore TODO: Introduce deprecation message for messageId
+					bundle.bundleId = bundle.bundleId || bundle.messageId
+					const bundleData = await selectBundleNested(activeProject.db)
+						.where("id", "=", bundle.bundleId)
+						.executeTakeFirst()
+					return bundleData
 				})
 			)
-		).flat()
 
-		const highlightedBundles = await Promise.all(
-			matchedBundles.map(async (bundle) => {
-				// @ts-ignore TODO: Introduce deprecation message for messageId
-				bundle.bundleId = bundle.bundleId || bundle.messageId
-				const bundleData = await selectBundleNested(activeProject.db)
-					.where("id", "=", bundle.bundleId)
-					.executeTakeFirst()
-				return bundleData
-			})
-		)
-
-		const highlightedMessagesHtml =
-			highlightedBundles.length > 0
-				? `<div class="highlighted-section">
+			const highlightedMessagesHtml =
+				highlightedBundles.length > 0
+					? `<div class="highlighted-section">
                         <div class="banner"><span class="active-dot"></span><span>Current file<span></div>
                         ${await Promise.all(
 													highlightedBundles.map(
@@ -239,59 +236,100 @@ export function createMessageWebviewProvider(args: {
 																	?.position,
 																isHighlighted: true,
 																workspaceFolder: args.workspaceFolder,
+																project: activeProject,
+																projectPath: session.path,
 															})
 													)
 												).then((htmls) => htmls.join(""))}
                     </div>`
-				: ""
+					: ""
 
-		const allMessagesBanner = '<div class="banner">All Messages</div>'
-		let mainContentHtml = ""
-		if (isLoading) {
-			mainContentHtml = createMessagesLoadingHtml()
-		} else if (bundles && bundles.length > 0) {
-			mainContentHtml = `${highlightedMessagesHtml}<main>${allMessagesBanner}${await Promise.all(
-				bundles.map(
-					async (message) =>
-						await createMessageHtml({
-							bundle: message,
-							isHighlighted: false,
-							workspaceFolder: args.workspaceFolder,
-						})
-				)
-			).then((htmls) => htmls.join(""))}</main>`
-		} else {
-			mainContentHtml = `${highlightedMessagesHtml}<main>${
-				allMessagesBanner + createNoMessagesFoundHtml()
-			}</main>`
-		}
+			const allMessagesBanner = '<div class="banner">All Messages</div>'
+			let mainContentHtml = ""
+			if (isLoading) {
+				mainContentHtml = createMessagesLoadingHtml()
+			} else if (bundles && bundles.length > 0) {
+				mainContentHtml = `${highlightedMessagesHtml}<main>${allMessagesBanner}${await Promise.all(
+					bundles.map(
+						async (message) =>
+							await createMessageHtml({
+								bundle: message,
+								isHighlighted: false,
+								workspaceFolder: args.workspaceFolder,
+								project: activeProject,
+								projectPath: session.path,
+							})
+					)
+				).then((htmls) => htmls.join(""))}</main>`
+			} else {
+				mainContentHtml = `${highlightedMessagesHtml}<main>${
+					allMessagesBanner + createNoMessagesFoundHtml()
+				}</main>`
+			}
 
-		if (webviewView) {
+			return mainContentHtml
+		})
+
+		if (rendered.status === "completed" && boundSession === session && webviewView) {
 			webviewView.webview.html = getHtml({
-				mainContent: mainContentHtml,
+				mainContent: rendered.value,
 				webview: webviewView.webview,
+				extensionUri: args.context.extensionUri,
 			})
 		}
 	}
 
 	const throttledUpdateWebviewContent = throttle(500, updateWebviewContent)
 
-	let webviewView: vscode.WebviewView | undefined
-
-	return {
-		resolveWebviewView(view: vscode.WebviewView) {
+	const controller: MessageViewController = {
+		bindProject(session) {
+			throttledUpdateWebviewContent.cancel()
+			boundSession = session
+			return {
+				dispose: async () => {
+					if (boundSession === session) boundSession = undefined
+					await queueSubscriptionTransition(async () => {
+						if (subscribedSession !== session) return
+						const currentSubscription = subscription
+						subscription = undefined
+						subscribedSession = undefined
+						await currentSubscription?.unsubscribe()
+						bundles = undefined
+						previousBundles = undefined
+					})
+				},
+			}
+		},
+		resolveWebviewView(
+			view: vscode.WebviewView,
+			_context: vscode.WebviewViewResolveContext<unknown>,
+			token: vscode.CancellationToken
+		) {
 			webviewView = view
+			const viewDisposables: vscode.Disposable[] = []
+			let viewDisposed = false
 
-			// Add disposal logic
-			view.onDidDispose(() => {
-				if (subscription) {
-					subscription.unsubscribe()
+			const disposeView = () => {
+				if (viewDisposed) return
+				viewDisposed = true
+				const ownsCurrentView = webviewView === view
+				if (ownsCurrentView) webviewView = undefined
+				for (const disposable of viewDisposables) disposable.dispose()
+				if (!ownsCurrentView) return
+				throttledUpdateWebviewContent.cancel()
+				if (debounceTimer) clearTimeout(debounceTimer)
+				void queueSubscriptionTransition(async () => {
+					const currentSubscription = subscription
 					subscription = undefined
-				}
-				bundles = undefined
-				previousBundles = undefined
-				subscribedToProjectPath = ""
-			})
+					subscribedSession = undefined
+					await currentSubscription?.unsubscribe()
+					bundles = undefined
+					previousBundles = undefined
+				})
+			}
+
+			view.onDidDispose(disposeView)
+			token?.onCancellationRequested?.(disposeView, undefined, viewDisposables)
 
 			view.webview.options = {
 				enableScripts: true,
@@ -307,61 +345,32 @@ export function createMessageWebviewProvider(args: {
 					}
 				},
 				undefined,
-				args.context.subscriptions
-			)
-
-			args.context.subscriptions.push(vscode.window.onDidChangeActiveTextEditor(debounceUpdate))
-			args.context.subscriptions.push(
-				vscode.workspace.onDidChangeTextDocument((event) => {
-					if (
-						vscode.window.activeTextEditor &&
-						event.document === vscode.window.activeTextEditor.document
-					) {
-						debounceUpdate()
-					}
-				})
-			)
-			args.context.subscriptions.push(vscode.workspace.onDidChangeConfiguration(updateMessages))
-
-			args.context.subscriptions.push(
-				CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.event(() => {
-					logger.debug("ON_DID_CREATE_MESSAGE event triggered")
-					updateMessages()
-				})
-			)
-
-			args.context.subscriptions.push(
-				CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.event(() => {
-					logger.debug("ON_DID_EXTRACT_MESSAGE event triggered")
-					updateMessages()
-				})
-			)
-
-			args.context.subscriptions.push(
-				CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.event(() => {
-					logger.debug("ON_DID_EDIT_MESSAGE event triggered - forcing immediate refresh")
-					// Use our special forced refresh that bypasses throttling and always updates
-					forceMessageRefresh()
-				})
-			)
-
-			args.context.subscriptions.push(
-				CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.event(() => {
-					logger.debug("ON_DID_PROJECT_TREE_VIEW_CHANGE event triggered")
-					updateMessages()
-				})
-			)
-
-			args.context.subscriptions.push(
-				CONFIGURATION.EVENTS.ON_DID_SETTINGS_VIEW_CHANGE.event(() => {
-					logger.debug("ON_DID_SETTINGS_VIEW_CHANGE event triggered")
-					updateMessages()
-				})
+				viewDisposables
 			)
 
 			updateMessages() // Initial update
 		},
 	}
+
+	args.context.subscriptions.push(
+		vscode.window.onDidChangeActiveTextEditor(debounceUpdate),
+		vscode.workspace.onDidChangeTextDocument((event) => {
+			if (
+				vscode.window.activeTextEditor &&
+				event.document === vscode.window.activeTextEditor.document
+			) {
+				debounceUpdate()
+			}
+		}),
+		vscode.workspace.onDidChangeConfiguration(updateMessages),
+		CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.event(() => void updateMessages()),
+		CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.event(() => void updateMessages()),
+		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.event(() => void forceMessageRefresh()),
+		CONFIGURATION.EVENTS.ON_DID_SETTINGS_VIEW_CHANGE.event(() => void updateMessages()),
+		CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.event(() => void updateMessages())
+	)
+
+	return controller
 }
 
 export async function createMessageHtml(args: {
@@ -378,15 +387,17 @@ export async function createMessageHtml(args: {
 	}
 	isHighlighted: boolean
 	workspaceFolder: vscode.WorkspaceFolder
+	project?: InlangProject
+	projectPath?: string
 }): Promise<string> {
 	const translationsTableHtml = await getTranslationsTableHtml({
 		bundle: args.bundle,
 		workspaceFolder: args.workspaceFolder,
+		project: args.project,
 	})
 
 	// Find the relative path from the workspace/git root
-	const activeState = getSafeState()
-	const selectedProjectPath = activeState?.selectedProjectPath ?? ""
+	const selectedProjectPath = args.projectPath ?? getSafeState()?.selectedProjectPath ?? ""
 	if (!selectedProjectPath) {
 		logger.warn("Unable to determine selected project path when rendering message HTML")
 	}
@@ -436,21 +447,19 @@ export function createMessagesLoadingHtml(): string {
 			</div>`
 }
 
-export function getHtml(args: { mainContent: string; webview: vscode.Webview }): string {
-	const context = vscode.extensions.getExtension("inlang.vs-code-extension")?.exports.context
-	if (!context) {
-		logger.error("Extension context is not available.")
-		return ""
-	}
-
+export function getHtml(args: {
+	mainContent: string
+	webview: vscode.Webview
+	extensionUri: vscode.Uri
+}): string {
 	const styleUri = args.webview.asWebviewUri(
-		vscode.Uri.joinPath(context.extensionUri, "assets", "styles.css")
+		vscode.Uri.joinPath(args.extensionUri, "assets", "styles.css")
 	)
 	const codiconsUri = args.webview.asWebviewUri(
-		vscode.Uri.joinPath(context.extensionUri, "assets", "codicon.css")
+		vscode.Uri.joinPath(args.extensionUri, "assets", "codicon.css")
 	)
 	const codiconsTtfUri = args.webview.asWebviewUri(
-		vscode.Uri.joinPath(context.extensionUri, "assets", "codicon.ttf")
+		vscode.Uri.joinPath(args.extensionUri, "assets", "codicon.ttf")
 	)
 
 	return `
@@ -588,8 +597,9 @@ export function getHtml(args: { mainContent: string; webview: vscode.Webview }):
 export async function getTranslationsTableHtml(args: {
 	bundle: BundleNested
 	workspaceFolder: vscode.WorkspaceFolder
+	project?: InlangProject
 }): Promise<string> {
-	const activeProject = getSafeState()?.project
+	const activeProject = args.project ?? getSafeState()?.project
 	if (!activeProject) {
 		logger.warn("Unable to render translations table because project is undefined")
 		return '<div class="section"><span class="message">Project is still loading...</span></div>'
@@ -668,4 +678,5 @@ export async function messageView(args: {
 	args.context.subscriptions.push(
 		vscode.window.registerWebviewViewProvider("messageView", provider)
 	)
+	return provider
 }

--- a/src/utilities/polling/pollQuery.test.ts
+++ b/src/utilities/polling/pollQuery.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import { pollQuery } from "./pollQuery.js"
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+afterEach(() => {
+	vi.useRealTimers()
+})
+
+describe("pollQuery", () => {
+	it("never overlaps a slow query", async () => {
+		vi.useFakeTimers()
+		const first = deferred<number>()
+		const query = vi.fn().mockReturnValueOnce(first.promise).mockResolvedValue(2)
+		const subscription = pollQuery(query, 100).subscribe(vi.fn())
+
+		await vi.advanceTimersByTimeAsync(500)
+		expect(query).toHaveBeenCalledTimes(1)
+
+		first.resolve(1)
+		await Promise.resolve()
+		await vi.advanceTimersByTimeAsync(100)
+		expect(query).toHaveBeenCalledTimes(2)
+		await subscription.unsubscribe()
+	})
+
+	it("waits for an in-flight query and suppresses its stale result on unsubscribe", async () => {
+		const queryResult = deferred<number>()
+		const subscriber = vi.fn()
+		const subscription = pollQuery(() => queryResult.promise, 100).subscribe(subscriber)
+		let settled = false
+		const disposal = subscription.unsubscribe().then(() => {
+			settled = true
+		})
+
+		await Promise.resolve()
+		expect(settled).toBe(false)
+		queryResult.resolve(1)
+		await disposal
+
+		expect(subscriber).not.toHaveBeenCalled()
+	})
+})

--- a/src/utilities/polling/pollQuery.ts
+++ b/src/utilities/polling/pollQuery.ts
@@ -2,7 +2,7 @@ type QueryFunction<T> = () => Promise<T>
 type Subscriber<T> = (value: T) => void
 
 interface Subscription {
-	unsubscribe: () => void
+	unsubscribe: () => Promise<void>
 }
 
 /**
@@ -17,30 +17,39 @@ export function pollQuery<T>(queryFn: QueryFunction<T>, interval: number = 2000)
 	return {
 		subscribe(subscriber: Subscriber<T>): Subscription {
 			let isDestroyed = false
+			let timeout: NodeJS.Timeout | undefined
+			let inFlight: Promise<void> | undefined
 
 			const executeQuery = async () => {
-				if (isDestroyed) return
-				try {
-					const result = await queryFn()
-					if (!isDestroyed) {
-						subscriber(result)
+				if (isDestroyed || inFlight) return
+				const execution = (async () => {
+					try {
+						const result = await queryFn()
+						if (!isDestroyed) {
+							subscriber(result)
+						}
+					} catch (error) {
+						if (!isDestroyed) console.error("Poll query error:", error)
+					} finally {
+						if (!isDestroyed) timeout = setTimeout(executeQuery, interval)
 					}
-				} catch (error) {
-					console.error("Poll query error:", error)
-				}
+				})()
+				inFlight = execution
+				await execution
+				if (inFlight === execution) inFlight = undefined
 			}
 
 			// Execute initial query
 			executeQuery()
 
-			// Set up polling interval
-			const intervalId = setInterval(executeQuery, interval)
-
 			// Return subscription object
 			return {
-				unsubscribe: () => {
+				unsubscribe: async () => {
 					isDestroyed = true
-					clearInterval(intervalId)
+					if (timeout) clearTimeout(timeout)
+					// Do not let the owning project close SQLite while this query is still using it.
+					// The pinned inlang/Kysely APIs do not expose cooperative query cancellation.
+					await inFlight
 				},
 			}
 		},

--- a/src/utilities/project/project.test.ts
+++ b/src/utilities/project/project.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest"
 import * as vscode from "vscode"
 import * as fs from "node:fs/promises"
-import { setState, state } from "../state.js"
+import { state } from "../state.js"
 import { CONFIGURATION } from "../../configuration.js"
 import { capture } from "../../services/telemetry/index.js"
 import {
@@ -12,7 +12,7 @@ import {
 	type ProjectViewNode,
 	projectView,
 } from "./project.js"
-import { loadProjectFromDirectory } from "@inlang/sdk"
+import { getProjectRuntime } from "./projectRuntime.js"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
 
 vi.mock("vscode", () => ({
@@ -36,12 +36,27 @@ vi.mock("vscode", () => ({
 	EventEmitter: vi.fn(),
 }))
 
-vi.mock("@inlang/sdk", () => ({
-	loadProjectFromDirectory: vi.fn(),
+const replaceProject = vi.hoisted(() => vi.fn())
+
+vi.mock("./projectRuntime.js", () => ({
+	getProjectRuntime: vi.fn(() => ({
+		replaceProject,
+		activeProject: () => {
+			const project = state().project
+			return project
+				? {
+						project,
+						runTask: async <T>(task: () => Promise<T>) => ({
+							status: "completed" as const,
+							value: await task(),
+						}),
+					}
+				: undefined
+		},
+	})),
 }))
 
 vi.mock("../state.js", () => ({
-	setState: vi.fn(),
 	state: vi.fn(() => ({
 		projectsInWorkspace: [
 			{
@@ -194,7 +209,11 @@ describe("getTreeItem", () => {
 describe("handleTreeSelection", () => {
 	const mockContext = {} as vscode.ExtensionContext
 
-	it.skip("should handle tree selection and update state", async () => {
+	beforeEach(() => {
+		replaceProject.mockReset().mockResolvedValue({ status: "committed" })
+	})
+
+	it("should replace the session when the user selects a project", async () => {
 		const selectedNode: ProjectViewNode = {
 			label: "SelectedProject",
 			path: "/path/to/selected",
@@ -217,13 +236,15 @@ describe("handleTreeSelection", () => {
 			},
 		}
 
-		// Mock the resolved value of loadProjectFromDirectory to return the mockProject
-		// @ts-expect-error
-		vi.mocked(loadProjectFromDirectory).mockResolvedValue(mockProject)
+		vi.mocked(state).mockReturnValue({
+			projectsInWorkspace: [],
+			selectedProjectPath: selectedNode.path,
+			project: mockProject,
+		} as any)
 
 		await handleTreeSelection({ selectedNode, fs, workspaceFolder })
 
-		expect(setState).toBeCalled()
+		expect(getProjectRuntime().replaceProject).toHaveBeenCalledWith(selectedNode.path)
 		expect(capture).toBeCalledWith(
 			expect.objectContaining({
 				event: "IDE-EXTENSION loaded project",
@@ -232,7 +253,6 @@ describe("handleTreeSelection", () => {
 				}),
 			})
 		)
-		expect(CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.fire).toBeCalled()
 	})
 
 	it("should show error message if project loading fails", async () => {
@@ -250,8 +270,7 @@ describe("handleTreeSelection", () => {
 			},
 		} as vscode.WorkspaceFolder
 
-		// @ts-expect-error
-		loadProjectFromDirectory.mockRejectedValue(new Error("Loading failed"))
+		replaceProject.mockRejectedValueOnce(new Error("Loading failed"))
 
 		await handleTreeSelection({ selectedNode, fs, workspaceFolder })
 
@@ -272,7 +291,7 @@ describe("handleTreeSelection", () => {
 
 		const error = new Error("Loading failed")
 
-		vi.mocked(loadProjectFromDirectory).mockRejectedValue(error)
+		replaceProject.mockRejectedValueOnce(error)
 
 		const mockWorkspaceFolder = {
 			uri: { fsPath: "/path/to/workspace" },

--- a/src/utilities/project/project.ts
+++ b/src/utilities/project/project.ts
@@ -1,12 +1,12 @@
 import * as vscode from "vscode"
-import { loadProjectFromDirectory } from "@inlang/sdk"
 import { CONFIGURATION } from "../../configuration.js"
 import { capture } from "../../services/telemetry/index.js"
-import { setState, state } from "../state.js"
+import { state } from "../state.js"
 import * as Sherlock from "@inlang/recommend-sherlock"
-import * as fs from "node:fs"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
 import path from "node:path"
+import { getProjectRuntime } from "./projectRuntime.js"
+import type { InlangProject } from "@inlang/sdk"
 
 let projectViewNodes: ProjectViewNode[] = []
 
@@ -99,43 +99,28 @@ export async function handleTreeSelection(args: {
 }): Promise<void> {
 	const selectedProject = path.normalize(args.selectedNode.path)
 
-	projectViewNodes = projectViewNodes.map((node) => ({
-		...node,
-		isSelected: node.path === args.selectedNode.path,
-	}))
-
-	const newSelectedProject = projectViewNodes.find((node) => node.isSelected)?.path as string
-	console.log(newSelectedProject)
-
 	try {
-		const inlangProject = await loadProjectFromDirectory({
-			path: newSelectedProject,
-			fs,
-		})
-
-		setState({
-			...state(),
-			project: inlangProject,
-			selectedProjectPath: newSelectedProject,
-		})
-
-		// Update decorations
-		CONFIGURATION.EVENTS.ON_DID_EDIT_MESSAGE.fire(undefined)
-		CONFIGURATION.EVENTS.ON_DID_CREATE_MESSAGE.fire(undefined)
-		CONFIGURATION.EVENTS.ON_DID_EXTRACT_MESSAGE.fire(undefined)
-		// Refresh the entire tree to reflect selection changes
-		CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.fire(undefined)
-		CONFIGURATION.EVENTS.ON_DID_ERROR_TREE_VIEW_CHANGE.fire(undefined)
+		const result = await getProjectRuntime<InlangProject>().replaceProject(selectedProject)
+		if (result.status === "failed") throw result.error
+		if (result.status !== "committed") return
+		projectViewNodes = projectViewNodes.map((node) => ({
+			...node,
+			isSelected: node.path === args.selectedNode.path,
+		}))
 
 		const isInWorkspaceRecommendation = await Sherlock.shouldRecommend({
 			fs: args.fs,
 			workingDirectory: path.normalize(args.workspaceFolder.uri.fsPath),
 		})
 
+		const activeProject = getProjectRuntime<InlangProject>().activeProject()
+		const projectErrors = activeProject
+			? await activeProject.runTask(() => activeProject.project.errors.get())
+			: undefined
 		capture({
 			event: "IDE-EXTENSION loaded project",
 			properties: {
-				errors: await inlangProject.errors.get(),
+				errors: projectErrors?.status === "completed" ? projectErrors.value : [],
 				isInWorkspaceRecommendation,
 			},
 		})
@@ -181,17 +166,4 @@ export const projectView = async (args: {
 	args.context.subscriptions.push(
 		vscode.window.registerTreeDataProvider("projectView", treeDataProvider)
 	)
-
-	// Trigger handleTreeSelection for the selected project after initializing the tree view
-	const selectedProjectPath = state().selectedProjectPath
-	if (selectedProjectPath) {
-		const selectedNode = projectViewNodes.find((node) => node.path === selectedProjectPath)
-		if (selectedNode) {
-			await handleTreeSelection({
-				selectedNode,
-				fs: args.fs,
-				workspaceFolder: args.workspaceFolder,
-			})
-		}
-	}
 }

--- a/src/utilities/project/projectRuntime.test.ts
+++ b/src/utilities/project/projectRuntime.test.ts
@@ -57,8 +57,29 @@ describe("project runtime", () => {
 		await runtime.replaceProject("/second.inlang")
 
 		expect(lease?.isCurrent()).toBe(false)
-		expect(resource.dispose).toHaveBeenCalledTimes(1)
+		expect(resource.dispose).toHaveBeenCalledWith("replacement")
 		expect(lease?.own({ dispose: vi.fn() })).toBe(false)
 		expect(runtime.activeProject()?.project).toBe(second)
+		const activeResource = { dispose: vi.fn() }
+		expect(runtime.activeProject()?.own(activeResource)).toBe(true)
+
+		await runtime.dispose()
+
+		expect(activeResource.dispose).toHaveBeenCalledWith("shutdown")
+	})
+
+	it("remembers a failed initial project path for recovery", async () => {
+		const runtime = createProjectRuntime({
+			loadProject: vi.fn(async () => Promise.reject(new Error("load failed"))),
+			prepareSession,
+			publishActiveSession: vi.fn(),
+		})
+
+		await expect(runtime.replaceProject("/failed.inlang")).resolves.toMatchObject({
+			status: "failed",
+		})
+
+		expect(runtime.activeProject()).toBeUndefined()
+		expect(runtime.lastRequestedProjectPath()).toBe("/failed.inlang")
 	})
 })

--- a/src/utilities/project/projectRuntime.test.ts
+++ b/src/utilities/project/projectRuntime.test.ts
@@ -1,0 +1,64 @@
+import { afterEach, describe, expect, it, vi } from "vitest"
+import {
+	createProjectRuntime,
+	disposeProjectRuntime,
+	getProjectRuntime,
+	installProjectRuntime,
+} from "./projectRuntime.js"
+
+function fakeProject(name: string) {
+	return {
+		name,
+		close: vi.fn(async () => undefined),
+	}
+}
+
+const prepareSession = vi.fn(async () => ({ activate: () => undefined }))
+
+afterEach(async () => {
+	await disposeProjectRuntime()
+})
+
+describe("project runtime", () => {
+	it("is the single installed lifecycle owner and disposes idempotently", async () => {
+		const project = fakeProject("active")
+		const runtime = createProjectRuntime({
+			loadProject: vi.fn(async () => project),
+			prepareSession,
+			publishActiveSession: vi.fn(),
+		})
+
+		installProjectRuntime(runtime)
+		expect(getProjectRuntime()).toBe(runtime)
+		expect(() => installProjectRuntime(runtime)).toThrow("already initialized")
+
+		await runtime.replaceProject("/active.inlang")
+		await disposeProjectRuntime()
+		await disposeProjectRuntime()
+
+		expect(project.close).toHaveBeenCalledTimes(1)
+		expect(() => getProjectRuntime()).toThrow("not initialized")
+	})
+
+	it("returns a lease that becomes stale after project replacement", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const runtime = createProjectRuntime({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession,
+			publishActiveSession: vi.fn(),
+		})
+
+		await runtime.replaceProject("/first.inlang")
+		const lease = runtime.activeProject()
+		const resource = { dispose: vi.fn() }
+		expect(lease?.own(resource)).toBe(true)
+		expect(lease?.project).toBe(first)
+		await runtime.replaceProject("/second.inlang")
+
+		expect(lease?.isCurrent()).toBe(false)
+		expect(resource.dispose).toHaveBeenCalledTimes(1)
+		expect(lease?.own({ dispose: vi.fn() })).toBe(false)
+		expect(runtime.activeProject()?.project).toBe(second)
+	})
+})

--- a/src/utilities/project/projectRuntime.ts
+++ b/src/utilities/project/projectRuntime.ts
@@ -1,0 +1,89 @@
+import {
+	createProjectSessionLifecycle,
+	type Disposable,
+	type ProjectSession,
+	type ProjectReplacementResult,
+	type PreparedProjectSession,
+	type ProjectTaskResult,
+} from "./projectSession.js"
+
+type CloseableProject = { close(): Promise<void> }
+
+export type ActiveProjectLease<Project extends CloseableProject> = {
+	readonly path: string
+	readonly project: Project
+	isCurrent(): boolean
+	own(resource: Disposable): boolean
+	runTask<T>(task: () => Promise<T>): Promise<ProjectTaskResult<T>>
+}
+
+export type ProjectRuntime<Project extends CloseableProject> = {
+	replaceProject(path: string): Promise<ProjectReplacementResult>
+	activeProject(): ActiveProjectLease<Project> | undefined
+	dispose(): Promise<void>
+}
+
+export function createProjectRuntime<Project extends CloseableProject>(args: {
+	loadProject(path: string): Promise<Project>
+	prepareSession(
+		session: ProjectSession<Project>,
+		resources: Disposable[]
+	): Promise<PreparedProjectSession>
+	publishActiveSession(session: ProjectSession<Project> | undefined): void
+	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
+	onError?(error: unknown, phase: "cleanup" | "activation" | "notification"): void
+}): ProjectRuntime<Project> {
+	let activeSession: ProjectSession<Project> | undefined
+	const lifecycle = createProjectSessionLifecycle({
+		loadProject: args.loadProject,
+		prepareSession: args.prepareSession,
+		setActiveSession: (session) => {
+			args.publishActiveSession(session)
+			activeSession = session
+		},
+		onDidReplaceSession: args.onDidReplaceSession,
+		onError: args.onError,
+	})
+
+	return {
+		replaceProject: lifecycle.replaceProject,
+		activeProject() {
+			const session = activeSession
+			if (!session) return undefined
+			return {
+				path: session.path,
+				project: session.project,
+				isCurrent: () => activeSession === session,
+				own: (resource) => session.own(resource),
+				runTask: (task) => session.runTask(task),
+			}
+		},
+		dispose: lifecycle.dispose,
+	}
+}
+
+let installedRuntime: ProjectRuntime<CloseableProject> | undefined
+let runtimeDisposal: Promise<void> | undefined
+
+export function installProjectRuntime<Project extends CloseableProject>(
+	runtime: ProjectRuntime<Project>
+) {
+	if (installedRuntime) throw new Error("Project runtime is already initialized")
+	installedRuntime = runtime
+}
+
+export function getProjectRuntime<Project extends CloseableProject = CloseableProject>() {
+	if (!installedRuntime) throw new Error("Project runtime is not initialized")
+	return installedRuntime as ProjectRuntime<Project>
+}
+
+export function disposeProjectRuntime() {
+	if (runtimeDisposal) return runtimeDisposal
+	const runtime = installedRuntime
+	if (!runtime) return Promise.resolve()
+	installedRuntime = undefined
+	runtimeDisposal = runtime.dispose().finally(() => {
+		runtimeDisposal = undefined
+	})
+	return runtimeDisposal
+}

--- a/src/utilities/project/projectRuntime.ts
+++ b/src/utilities/project/projectRuntime.ts
@@ -20,6 +20,7 @@ export type ActiveProjectLease<Project extends CloseableProject> = {
 export type ProjectRuntime<Project extends CloseableProject> = {
 	replaceProject(path: string): Promise<ProjectReplacementResult>
 	activeProject(): ActiveProjectLease<Project> | undefined
+	lastRequestedProjectPath(): string | undefined
 	dispose(): Promise<void>
 }
 
@@ -34,6 +35,7 @@ export function createProjectRuntime<Project extends CloseableProject>(args: {
 	onError?(error: unknown, phase: "cleanup" | "activation" | "notification"): void
 }): ProjectRuntime<Project> {
 	let activeSession: ProjectSession<Project> | undefined
+	let lastRequestedProjectPath: string | undefined
 	const lifecycle = createProjectSessionLifecycle({
 		loadProject: args.loadProject,
 		prepareSession: args.prepareSession,
@@ -46,7 +48,10 @@ export function createProjectRuntime<Project extends CloseableProject>(args: {
 	})
 
 	return {
-		replaceProject: lifecycle.replaceProject,
+		replaceProject(path) {
+			lastRequestedProjectPath = path
+			return lifecycle.replaceProject(path)
+		},
 		activeProject() {
 			const session = activeSession
 			if (!session) return undefined
@@ -58,6 +63,7 @@ export function createProjectRuntime<Project extends CloseableProject>(args: {
 				runTask: (task) => session.runTask(task),
 			}
 		},
+		lastRequestedProjectPath: () => lastRequestedProjectPath,
 		dispose: lifecycle.dispose,
 	}
 }

--- a/src/utilities/project/projectSession.test.ts
+++ b/src/utilities/project/projectSession.test.ts
@@ -1,0 +1,505 @@
+import { describe, expect, it, vi } from "vitest"
+import { createProjectSessionLifecycle, deactivateBeforeClose } from "./projectSession.js"
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+function fakeProject(name: string) {
+	return {
+		name,
+		close: vi.fn(async () => undefined),
+	}
+}
+
+function preparedSession() {
+	return { activate: () => undefined }
+}
+
+describe("project session lifecycle", () => {
+	it("replaces the active project and disposes its resources exactly once", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const firstResource = { dispose: vi.fn() }
+		const secondResource = { dispose: vi.fn() }
+		const activeProjects: Array<string | undefined> = []
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async (session, resources) => {
+				resources.push(session.project === first ? firstResource : secondResource)
+				return preparedSession()
+			}),
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		await lifecycle.replaceProject("/first.inlang")
+		await lifecycle.replaceProject("/second.inlang")
+
+		expect(activeProjects.at(-1)).toBe("second")
+		expect(firstResource.dispose).toHaveBeenCalledTimes(1)
+		expect(first.close).toHaveBeenCalledTimes(1)
+		expect(secondResource.dispose).not.toHaveBeenCalled()
+		expect(second.close).not.toHaveBeenCalled()
+
+		await lifecycle.dispose()
+		await lifecycle.dispose()
+
+		expect(secondResource.dispose).toHaveBeenCalledTimes(1)
+		expect(second.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("keeps the active session when loading or installing its replacement fails", async () => {
+		const first = fakeProject("first")
+		const failed = fakeProject("failed")
+		const firstResource = { dispose: vi.fn() }
+		const activeProjects: Array<string | undefined> = []
+		const loadProject = vi
+			.fn()
+			.mockResolvedValueOnce(first)
+			.mockRejectedValueOnce(new Error("load failed"))
+			.mockResolvedValueOnce(failed)
+		const failedResource = { dispose: vi.fn() }
+		const prepareSession = vi.fn(async (session, resources) => {
+			resources.push(session.project === first ? firstResource : failedResource)
+			if (session.project === failed) throw new Error("install failed")
+			return preparedSession()
+		})
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject,
+			prepareSession,
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		await lifecycle.replaceProject("/first.inlang")
+		await expect(lifecycle.replaceProject("/load-fails.inlang")).resolves.toMatchObject({
+			status: "failed",
+			error: expect.objectContaining({ message: "load failed" }),
+		})
+		expect(activeProjects.at(-1)).toBe("first")
+		expect(first.close).not.toHaveBeenCalled()
+
+		await expect(lifecycle.replaceProject("/install-fails.inlang")).resolves.toMatchObject({
+			status: "failed",
+			error: expect.objectContaining({ message: "install failed" }),
+		})
+		expect(activeProjects.at(-1)).toBe("first")
+		expect(firstResource.dispose).not.toHaveBeenCalled()
+		expect(first.close).not.toHaveBeenCalled()
+		expect(failedResource.dispose).toHaveBeenCalledTimes(1)
+		expect(failed.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("keeps the current session published while its replacement is being prepared", async () => {
+		const preparation = deferred<void>()
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const activeProjects: Array<string | undefined> = []
+		const prepareSession = vi.fn(async (session: { project: typeof first }) => {
+			if (session.project === second) await preparation.promise
+			return preparedSession()
+		})
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession,
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		await lifecycle.replaceProject("/first.inlang")
+		const replacement = lifecycle.replaceProject("/second.inlang")
+		await vi.waitFor(() => expect(prepareSession).toHaveBeenCalledTimes(2))
+		expect(activeProjects.at(-1)).toBe("first")
+
+		preparation.resolve()
+		await replacement
+
+		expect(activeProjects.at(-1)).toBe("second")
+	})
+
+	it("does not let a stale asynchronous load replace a newer selection", async () => {
+		const slow = deferred<ReturnType<typeof fakeProject>>()
+		const fast = deferred<ReturnType<typeof fakeProject>>()
+		const slowProject = fakeProject("slow")
+		const fastProject = fakeProject("fast")
+		const activeProjects: Array<string | undefined> = []
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: (path) => (path.includes("slow") ? slow.promise : fast.promise),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		const slowReplacement = lifecycle.replaceProject("/slow.inlang")
+		const fastReplacement = lifecycle.replaceProject("/fast.inlang")
+		fast.resolve(fastProject)
+		expect(await fastReplacement).toEqual({ status: "committed" })
+		slow.resolve(slowProject)
+		expect(await slowReplacement).toEqual({ status: "superseded" })
+
+		expect(activeProjects.at(-1)).toBe("fast")
+		expect(slowProject.close).toHaveBeenCalledTimes(1)
+		expect(fastProject.close).not.toHaveBeenCalled()
+	})
+
+	it("returns a failed result when a superseded candidate cannot be closed", async () => {
+		const slow = deferred<ReturnType<typeof fakeProject>>()
+		const slowProject = fakeProject("slow")
+		slowProject.close.mockRejectedValueOnce(new Error("close failed"))
+		const fastProject = fakeProject("fast")
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: (path) => (path.includes("slow") ? slow.promise : Promise.resolve(fastProject)),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: vi.fn(),
+		})
+
+		const slowReplacement = lifecycle.replaceProject("/slow.inlang")
+		expect(await lifecycle.replaceProject("/fast.inlang")).toEqual({ status: "committed" })
+		slow.resolve(slowProject)
+
+		expect(await slowReplacement).toMatchObject({
+			status: "failed",
+			error: expect.objectContaining({ message: "Failed to close superseded project" }),
+		})
+		expect(fastProject.close).not.toHaveBeenCalled()
+	})
+
+	it("publishes only the latest project during a rapid A to B to C switch", async () => {
+		const loads = {
+			a: deferred<ReturnType<typeof fakeProject>>(),
+			b: deferred<ReturnType<typeof fakeProject>>(),
+			c: deferred<ReturnType<typeof fakeProject>>(),
+		}
+		const projects = {
+			a: fakeProject("a"),
+			b: fakeProject("b"),
+			c: fakeProject("c"),
+		}
+		const activeProjects: Array<string | undefined> = []
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: (path) => loads[path.at(1) as "a" | "b" | "c"].promise,
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		const replacements = [
+			lifecycle.replaceProject("/a.inlang"),
+			lifecycle.replaceProject("/b.inlang"),
+			lifecycle.replaceProject("/c.inlang"),
+		]
+		loads.b.resolve(projects.b)
+		loads.c.resolve(projects.c)
+		loads.a.resolve(projects.a)
+
+		expect(await Promise.all(replacements)).toEqual([
+			{ status: "superseded" },
+			{ status: "superseded" },
+			{ status: "committed" },
+		])
+		expect(activeProjects).toEqual(["c"])
+		expect(projects.a.close).toHaveBeenCalledTimes(1)
+		expect(projects.b.close).toHaveBeenCalledTimes(1)
+		expect(projects.c.close).not.toHaveBeenCalled()
+	})
+
+	it("does not activate a session superseded while its resources are being prepared", async () => {
+		const firstInstall = deferred<void>()
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const activeProjects: Array<string | undefined> = []
+		const activateSession = vi.fn()
+		const prepareSession = vi.fn(async (session: { project: typeof first }) => {
+			if (session.project === first) await firstInstall.promise
+			return { activate: () => activateSession(session) }
+		})
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession,
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+		})
+
+		const firstReplacement = lifecycle.replaceProject("/first.inlang")
+		await vi.waitFor(() => expect(prepareSession).toHaveBeenCalledTimes(1))
+		const secondReplacement = lifecycle.replaceProject("/second.inlang")
+		firstInstall.resolve()
+
+		expect(await firstReplacement).toEqual({ status: "superseded" })
+		expect(await secondReplacement).toEqual({ status: "committed" })
+		expect(activeProjects.at(-1)).toBe("second")
+		expect(first.close).toHaveBeenCalledTimes(1)
+		expect(activateSession).toHaveBeenCalledTimes(1)
+		expect(activateSession.mock.calls[0]?.[0].project).toBe(second)
+	})
+
+	it("waits for project resources to quiesce before closing the project", async () => {
+		const resourceDisposal = deferred<void>()
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async (session, resources) => {
+				if (session.project === first) {
+					resources.push({ dispose: () => resourceDisposal.promise })
+				}
+				return preparedSession()
+			}),
+			setActiveSession: vi.fn(),
+		})
+		await lifecycle.replaceProject("/first.inlang")
+
+		const replacement = lifecycle.replaceProject("/second.inlang")
+		let replacementSettled = false
+		void replacement.then(() => {
+			replacementSettled = true
+		})
+		await Promise.resolve()
+		expect(replacementSettled).toBe(false)
+		expect(first.close).not.toHaveBeenCalled()
+		resourceDisposal.resolve()
+		await replacement
+
+		expect(first.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("waits for active project tasks before closing and rejects stale work", async () => {
+		const runningTask = deferred<void>()
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		let firstSession: any
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => {
+				if (session?.project === first) firstSession = session
+			},
+		})
+		await lifecycle.replaceProject("/first.inlang")
+		const task = firstSession.runTask(async () => {
+			await runningTask.promise
+			return "finished"
+		})
+
+		const replacement = lifecycle.replaceProject("/second.inlang")
+		await Promise.resolve()
+		expect(first.close).not.toHaveBeenCalled()
+		runningTask.resolve()
+		await replacement
+
+		expect(await task).toEqual({ status: "inactive" })
+		expect(first.close).toHaveBeenCalledTimes(1)
+		const staleWork = vi.fn(async () => "stale")
+		expect(await firstSession.runTask(staleWork)).toEqual({ status: "inactive" })
+		expect(staleWork).not.toHaveBeenCalled()
+	})
+
+	it("distinguishes a completed undefined value from inactive work", async () => {
+		const project = fakeProject("project")
+		let session: any
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn(async () => project),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (value) => {
+				session = value
+			},
+		})
+		await lifecycle.replaceProject("/project.inlang")
+
+		expect(await session.runTask(async () => undefined)).toEqual({
+			status: "completed",
+			value: undefined,
+		})
+	})
+
+	it("deactivates callbacks before waiting for old project tasks", async () => {
+		const runningTask = deferred<void>()
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const callbackRegistration = { dispose: vi.fn() }
+		let outputDisposed = false
+		const taskOutput = {
+			dispose: vi.fn(() => {
+				outputDisposed = true
+			}),
+			write: vi.fn(() => {
+				if (outputDisposed) throw new Error("task output was disposed before the task settled")
+			}),
+		}
+		let firstSession: any
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async (session, resources) => {
+				if (session.project === first) {
+					resources.push(taskOutput, deactivateBeforeClose(callbackRegistration))
+				}
+				return preparedSession()
+			}),
+			setActiveSession: (session) => {
+				if (session?.project === first) firstSession = session
+			},
+		})
+		await lifecycle.replaceProject("/first.inlang")
+		void firstSession.runTask(async () => {
+			await runningTask.promise
+			taskOutput.write()
+		})
+
+		const replacement = lifecycle.replaceProject("/second.inlang")
+		await vi.waitFor(() => expect(callbackRegistration.dispose).toHaveBeenCalledTimes(1))
+
+		expect(first.close).not.toHaveBeenCalled()
+		expect(taskOutput.dispose).not.toHaveBeenCalled()
+		runningTask.resolve()
+		await replacement
+		expect(taskOutput.write).toHaveBeenCalledTimes(1)
+		expect(taskOutput.dispose).toHaveBeenCalledTimes(1)
+		expect(first.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("reports old-session cleanup errors without turning a committed replacement into failure", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const cleanupError = new Error("cleanup failed")
+		const onError = vi.fn()
+		const activeProjects: Array<string | undefined> = []
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async (session, resources) => {
+				if (session.project === first) {
+					resources.push({ dispose: () => Promise.reject(cleanupError) })
+				}
+				return preparedSession()
+			}),
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+			onError,
+		})
+
+		await lifecycle.replaceProject("/first.inlang")
+		await expect(lifecycle.replaceProject("/second.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+
+		expect(activeProjects.at(-1)).toBe("second")
+		expect(first.close).toHaveBeenCalledTimes(1)
+		expect(onError).toHaveBeenCalledTimes(1)
+	})
+
+	it("keeps committed-success semantics when notification and error reporting fail", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const notificationError = new Error("notification failed")
+		const consoleError = vi.spyOn(console, "error").mockImplementation(() => undefined)
+		const activeProjects: Array<string | undefined> = []
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => activeProjects.push(session?.project.name),
+			onDidReplaceSession: vi
+				.fn()
+				.mockResolvedValueOnce(undefined)
+				.mockRejectedValueOnce(notificationError),
+			onError: () => {
+				throw new Error("reporting failed")
+			},
+		})
+
+		await lifecycle.replaceProject("/first.inlang")
+		await expect(lifecycle.replaceProject("/second.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+
+		expect(activeProjects.at(-1)).toBe("second")
+		expect(first.close).toHaveBeenCalledTimes(1)
+		expect(consoleError).toHaveBeenCalledWith(
+			"Failed to report project-session error",
+			expect.any(Error)
+		)
+		consoleError.mockRestore()
+	})
+
+	it("preserves publication and cleanup errors when a candidate cannot be published", async () => {
+		const candidate = fakeProject("candidate")
+		const publicationError = new Error("publication failed")
+		candidate.close.mockRejectedValueOnce(new Error("cleanup failed"))
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn(async () => candidate),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => {
+				if (session) throw publicationError
+			},
+		})
+
+		const result = await lifecycle.replaceProject("/candidate.inlang")
+
+		expect(result).toMatchObject({
+			status: "failed",
+			error: expect.objectContaining({
+				message: "Failed to publish and clean up project session",
+			}),
+		})
+		if (result.status !== "failed" || !(result.error instanceof AggregateError)) {
+			throw new Error("Expected an aggregate publication failure")
+		}
+		expect(result.error.errors).toContain(publicationError)
+		expect(candidate.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("closes a candidate when disposed while its resources are being prepared", async () => {
+		const preparation = deferred<void>()
+		const candidate = fakeProject("candidate")
+		const prepareSession = vi.fn(async () => {
+			await preparation.promise
+			return preparedSession()
+		})
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn(async () => candidate),
+			prepareSession,
+			setActiveSession: vi.fn(),
+		})
+
+		const replacement = lifecycle.replaceProject("/candidate.inlang")
+		await vi.waitFor(() => expect(prepareSession).toHaveBeenCalledTimes(1))
+		const disposal = lifecycle.dispose()
+		preparation.resolve()
+
+		expect(await replacement).toEqual({ status: "superseded" })
+		await disposal
+		expect(candidate.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("closes an in-flight project when disposed during loading", async () => {
+		const loading = deferred<ReturnType<typeof fakeProject>>()
+		const loadedProject = fakeProject("loaded")
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: () => loading.promise,
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: vi.fn(),
+		})
+
+		const replacement = lifecycle.replaceProject("/loaded.inlang")
+		const disposal = lifecycle.dispose()
+		loading.resolve(loadedProject)
+
+		expect(await replacement).toEqual({ status: "superseded" })
+		await disposal
+		expect(loadedProject.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("closes the active project when clearing published state fails during disposal", async () => {
+		const project = fakeProject("active")
+		const publicationError = new Error("publication failed")
+		const lifecycle = createProjectSessionLifecycle<ReturnType<typeof fakeProject>>({
+			loadProject: vi.fn(async () => project),
+			prepareSession: vi.fn(async () => preparedSession()),
+			setActiveSession: (session) => {
+				if (!session) throw publicationError
+			},
+		})
+		await lifecycle.replaceProject("/active.inlang")
+
+		await expect(lifecycle.dispose()).rejects.toMatchObject({
+			message: "Failed to dispose project lifecycle",
+		})
+		expect(project.close).toHaveBeenCalledTimes(1)
+	})
+})

--- a/src/utilities/project/projectSession.ts
+++ b/src/utilities/project/projectSession.ts
@@ -7,17 +7,19 @@ export type ProjectSession<Project extends { close(): Promise<void> }> = {
 
 export type ProjectTaskResult<T> = { status: "completed"; value: T } | { status: "inactive" }
 
+export type ProjectSessionDisposalReason = "replacement" | "shutdown"
+
 export type Disposable = {
-	dispose(): unknown
-	deactivate?(): unknown
+	dispose(reason?: ProjectSessionDisposalReason): unknown
+	deactivate?(reason?: ProjectSessionDisposalReason): unknown
 }
 
 export function deactivateBeforeClose(resource: Disposable): Disposable {
 	let disposal: Promise<void> | undefined
-	const dispose = () => {
+	const dispose = (reason?: ProjectSessionDisposalReason) => {
 		if (!disposal) {
 			try {
-				disposal = Promise.resolve(resource.dispose()).then(() => undefined)
+				disposal = Promise.resolve(resource.dispose(reason)).then(() => undefined)
 			} catch (error) {
 				disposal = Promise.reject(error)
 			}
@@ -55,7 +57,11 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
 	onError?(error: unknown, phase: "cleanup" | "activation" | "notification"): void
 }) {
-	let activeSession: (ProjectSession<Project> & { dispose(): Promise<void> }) | undefined
+	let activeSession:
+		| (ProjectSession<Project> & {
+				dispose(reason?: ProjectSessionDisposalReason): Promise<void>
+		  })
+		| undefined
 	let disposed = false
 	let disposal: Promise<void> | undefined
 	let generation = 0
@@ -91,7 +97,7 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 					tasks.delete(execution)
 				}
 			},
-			async dispose() {
+			async dispose(reason: ProjectSessionDisposalReason = "replacement") {
 				if (sessionDisposed) return
 				sessionDisposed = true
 				active = false
@@ -102,7 +108,7 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 					try {
 						earlyDisposals.set(
 							resource,
-							Promise.resolve(resource.deactivate()).then(
+							Promise.resolve(resource.deactivate(reason)).then(
 								() => ({ status: "fulfilled", value: undefined }),
 								(reason) => ({ status: "rejected", reason })
 							)
@@ -123,7 +129,7 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 						continue
 					}
 					try {
-						await resource.dispose()
+						await resource.dispose(reason)
 					} catch (error) {
 						errors.push(error)
 					}
@@ -147,7 +153,9 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 	}
 
 	async function disposeCandidate(
-		candidate: ProjectSession<Project> & { dispose(): Promise<void> },
+		candidate: ProjectSession<Project> & {
+			dispose(reason?: ProjectSessionDisposalReason): Promise<void>
+		},
 		message: string
 	): Promise<Extract<ProjectReplacementResult, { status: "failed" }> | undefined> {
 		try {
@@ -244,7 +252,7 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 			}
 			activeSession = candidate
 			try {
-				await previous?.dispose()
+				await previous?.dispose("replacement")
 			} catch (error) {
 				reportError(error, "cleanup")
 			}
@@ -292,7 +300,7 @@ export function createProjectSessionLifecycle<Project extends { close(): Promise
 					errors.push(error)
 				}
 				try {
-					await previous?.dispose()
+					await previous?.dispose("shutdown")
 				} catch (error) {
 					errors.push(error)
 				}

--- a/src/utilities/project/projectSession.ts
+++ b/src/utilities/project/projectSession.ts
@@ -1,0 +1,306 @@
+export type ProjectSession<Project extends { close(): Promise<void> }> = {
+	readonly path: string
+	readonly project: Project
+	own(resource: Disposable): boolean
+	runTask<T>(task: () => Promise<T>): Promise<ProjectTaskResult<T>>
+}
+
+export type ProjectTaskResult<T> = { status: "completed"; value: T } | { status: "inactive" }
+
+export type Disposable = {
+	dispose(): unknown
+	deactivate?(): unknown
+}
+
+export function deactivateBeforeClose(resource: Disposable): Disposable {
+	let disposal: Promise<void> | undefined
+	const dispose = () => {
+		if (!disposal) {
+			try {
+				disposal = Promise.resolve(resource.dispose()).then(() => undefined)
+			} catch (error) {
+				disposal = Promise.reject(error)
+			}
+		}
+		return disposal
+	}
+	return { deactivate: dispose, dispose }
+}
+
+export type ProjectSessionLifecycle = {
+	replaceProject(path: string): Promise<ProjectReplacementResult>
+	dispose(): Promise<void>
+}
+
+export type ProjectReplacementResult =
+	| { status: "committed" }
+	| { status: "superseded" }
+	| { status: "failed"; error: unknown }
+
+const COMMITTED = { status: "committed" } as const
+const SUPERSEDED = { status: "superseded" } as const
+
+export type PreparedProjectSession = {
+	activate(): void
+	afterPreviousDisposed?(): Promise<void> | void
+}
+
+export function createProjectSessionLifecycle<Project extends { close(): Promise<void> }>(args: {
+	loadProject(path: string): Promise<Project>
+	prepareSession(
+		session: ProjectSession<Project>,
+		resources: Disposable[]
+	): Promise<PreparedProjectSession>
+	setActiveSession(session: ProjectSession<Project> | undefined): void
+	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
+	onError?(error: unknown, phase: "cleanup" | "activation" | "notification"): void
+}) {
+	let activeSession: (ProjectSession<Project> & { dispose(): Promise<void> }) | undefined
+	let disposed = false
+	let disposal: Promise<void> | undefined
+	let generation = 0
+	let commitQueue = Promise.resolve()
+	const replacements = new Set<Promise<ProjectReplacementResult>>()
+
+	function createSession(path: string, project: Project) {
+		let resources: Disposable[] = []
+		let sessionDisposed = false
+		let active = false
+		const tasks = new Set<Promise<unknown>>()
+		return {
+			path,
+			project,
+			resources,
+			activate() {
+				active = true
+			},
+			own(resource: Disposable) {
+				if (!active || sessionDisposed) return false
+				resources.push(resource)
+				return true
+			},
+			async runTask<T>(task: () => Promise<T>) {
+				if (!active || sessionDisposed) return { status: "inactive" } as const
+				const execution = task()
+				tasks.add(execution)
+				try {
+					const value = await execution
+					if (!active || sessionDisposed) return { status: "inactive" } as const
+					return { status: "completed", value } as const
+				} finally {
+					tasks.delete(execution)
+				}
+			},
+			async dispose() {
+				if (sessionDisposed) return
+				sessionDisposed = true
+				active = false
+				const errors: unknown[] = []
+				const earlyDisposals = new Map<Disposable, Promise<PromiseSettledResult<void>>>()
+				for (const resource of resources.toReversed()) {
+					if (!resource.deactivate) continue
+					try {
+						earlyDisposals.set(
+							resource,
+							Promise.resolve(resource.deactivate()).then(
+								() => ({ status: "fulfilled", value: undefined }),
+								(reason) => ({ status: "rejected", reason })
+							)
+						)
+					} catch (error) {
+						errors.push(error)
+					}
+				}
+				const taskResults = await Promise.allSettled([...tasks])
+				for (const result of taskResults) {
+					if (result.status === "rejected") errors.push(result.reason)
+				}
+				for (const resource of resources.toReversed()) {
+					const earlyDisposal = earlyDisposals.get(resource)
+					if (earlyDisposal) {
+						const result = await earlyDisposal
+						if (result.status === "rejected") errors.push(result.reason)
+						continue
+					}
+					try {
+						await resource.dispose()
+					} catch (error) {
+						errors.push(error)
+					}
+				}
+				try {
+					await project.close()
+				} catch (error) {
+					errors.push(error)
+				}
+				if (errors.length > 0) throw new AggregateError(errors, "Failed to dispose project session")
+			},
+		}
+	}
+
+	function reportError(error: unknown, phase: "cleanup" | "activation" | "notification") {
+		try {
+			args.onError?.(error, phase)
+		} catch (reportingError) {
+			console.error("Failed to report project-session error", reportingError)
+		}
+	}
+
+	async function disposeCandidate(
+		candidate: ProjectSession<Project> & { dispose(): Promise<void> },
+		message: string
+	): Promise<Extract<ProjectReplacementResult, { status: "failed" }> | undefined> {
+		try {
+			await candidate.dispose()
+			return undefined
+		} catch (error) {
+			return { status: "failed", error: new AggregateError([error], message) }
+		}
+	}
+
+	async function replaceProject(path: string) {
+		if (disposed) return SUPERSEDED
+		const replacementGeneration = ++generation
+		let project: Project
+		try {
+			project = await args.loadProject(path)
+		} catch (error) {
+			if (disposed || replacementGeneration !== generation) return SUPERSEDED
+			return { status: "failed", error } as const
+		}
+
+		const candidate = createSession(path, project)
+		const commit = commitQueue.then(async () => {
+			if (disposed || replacementGeneration !== generation) {
+				const failure = await disposeCandidate(candidate, "Failed to close superseded project")
+				if (failure) return failure
+				return SUPERSEDED
+			}
+
+			const previous = activeSession
+			let preparedSession: PreparedProjectSession
+			try {
+				preparedSession = await args.prepareSession(candidate, candidate.resources)
+			} catch (error) {
+				try {
+					await candidate.dispose()
+				} catch (cleanupError) {
+					return {
+						status: "failed",
+						error: new AggregateError([error, cleanupError], "Project preparation failed"),
+					} as const
+				}
+				return { status: "failed", error } as const
+			}
+
+			if (disposed || replacementGeneration !== generation) {
+				const failure = await disposeCandidate(candidate, "Failed to close superseded project")
+				if (failure) return failure
+				return SUPERSEDED
+			}
+
+			candidate.activate()
+			try {
+				preparedSession.activate()
+			} catch (error) {
+				try {
+					await candidate.dispose()
+				} catch (cleanupError) {
+					return {
+						status: "failed",
+						error: new AggregateError([error, cleanupError], "Project activation failed"),
+					} as const
+				}
+				return { status: "failed", error } as const
+			}
+			try {
+				args.setActiveSession(candidate)
+			} catch (error) {
+				const cleanupFailure = await disposeCandidate(
+					candidate,
+					"Failed to clean up unpublished project"
+				)
+				try {
+					args.setActiveSession(previous)
+				} catch (rollbackError) {
+					return {
+						status: "failed",
+						error: new AggregateError(
+							[error, cleanupFailure?.error, rollbackError].filter(Boolean),
+							"Failed to publish project session"
+						),
+					} as const
+				}
+				if (cleanupFailure) {
+					return {
+						status: "failed",
+						error: new AggregateError(
+							[error, cleanupFailure.error],
+							"Failed to publish and clean up project session"
+						),
+					} as const
+				}
+				return { status: "failed", error } as const
+			}
+			activeSession = candidate
+			try {
+				await previous?.dispose()
+			} catch (error) {
+				reportError(error, "cleanup")
+			}
+			try {
+				await preparedSession.afterPreviousDisposed?.()
+			} catch (error) {
+				reportError(error, "activation")
+			}
+			try {
+				await args.onDidReplaceSession?.(candidate)
+			} catch (error) {
+				reportError(error, "notification")
+			}
+			return COMMITTED
+		})
+		commitQueue = commit.then(
+			() => undefined,
+			() => undefined
+		)
+		return commit
+	}
+
+	function trackReplacement(path: string) {
+		const replacement = replaceProject(path)
+		replacements.add(replacement)
+		replacement.finally(() => replacements.delete(replacement)).catch(() => undefined)
+		return replacement
+	}
+
+	return {
+		replaceProject: trackReplacement,
+		dispose() {
+			if (disposal) return disposal
+			disposed = true
+			generation += 1
+			disposal = (async () => {
+				await Promise.allSettled([...replacements])
+				await commitQueue
+				const previous = activeSession
+				activeSession = undefined
+				const errors: unknown[] = []
+				try {
+					args.setActiveSession(undefined)
+				} catch (error) {
+					errors.push(error)
+				}
+				try {
+					await previous?.dispose()
+				} catch (error) {
+					errors.push(error)
+				}
+				if (errors.length > 0) {
+					throw new AggregateError(errors, "Failed to dispose project lifecycle")
+				}
+			})()
+			return disposal
+		},
+	}
+}

--- a/src/utilities/project/selectBundleById.test.ts
+++ b/src/utilities/project/selectBundleById.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it, vi } from "vitest"
+import { selectBundleNested } from "@inlang/sdk"
+import { selectBundleById } from "./selectBundleById.js"
+
+vi.mock("@inlang/sdk", () => ({
+	selectBundleNested: vi.fn(),
+}))
+
+describe("selectBundleById", () => {
+	it("queries the explicit project's bundle id", async () => {
+		const executeTakeFirst = vi.fn(async () => ({ id: "welcome" }))
+		const where = vi.fn(() => ({ executeTakeFirst }))
+		vi.mocked(selectBundleNested).mockReturnValue({ where } as any)
+		const project = { db: {} }
+
+		await expect(selectBundleById(project as any, "welcome")).resolves.toEqual({
+			id: "welcome",
+		})
+		expect(selectBundleNested).toHaveBeenCalledWith(project.db)
+		expect(where).toHaveBeenCalledWith("bundle.id", "=", "welcome")
+	})
+})

--- a/src/utilities/project/selectBundleById.ts
+++ b/src/utilities/project/selectBundleById.ts
@@ -1,0 +1,5 @@
+import { selectBundleNested, type InlangProject } from "@inlang/sdk"
+
+export function selectBundleById(project: InlangProject, bundleId: string) {
+	return selectBundleNested(project.db).where("bundle.id", "=", bundleId).executeTakeFirst()
+}

--- a/src/utilities/recommendation/recommendation.test.ts
+++ b/src/utilities/recommendation/recommendation.test.ts
@@ -66,7 +66,7 @@ describe("recommendationBannerView", () => {
 				name: "test-workspace",
 				index: 0,
 			},
-			context: {} as vscode.ExtensionContext,
+			context: { subscriptions: [] } as unknown as vscode.ExtensionContext,
 		}
 
 		await recommendationBannerView(args)

--- a/src/utilities/recommendation/recommendation.ts
+++ b/src/utilities/recommendation/recommendation.ts
@@ -217,21 +217,12 @@ export async function getRecommendationViewHtml(args: {
 		</html>`
 }
 
-let recommendationBannerProvider: vscode.Disposable | undefined
-
 export async function recommendationBannerView(args: {
 	context: vscode.ExtensionContext
 	workspaceFolder: vscode.WorkspaceFolder
 	fs: FileSystem
 }) {
-	// Check if the provider is already registered
-	if (recommendationBannerProvider) {
-		console.log("Disposing existing Webview View provider for 'recommendationBanner'")
-		recommendationBannerProvider.dispose()
-	}
-
-	// Register the Webview View provider
-	recommendationBannerProvider = vscode.window.registerWebviewViewProvider(
+	const recommendationBannerProvider = vscode.window.registerWebviewViewProvider(
 		"recommendationBanner",
 		createRecommendationView({
 			fs: args.fs,
@@ -239,6 +230,7 @@ export async function recommendationBannerView(args: {
 			workspaceFolder: args.workspaceFolder,
 		})
 	)
+	args.context.subscriptions.push(recommendationBannerProvider)
 }
 
 const debounce = <T extends (...args: any[]) => void>(

--- a/src/utilities/settings/settingsView.test.ts
+++ b/src/utilities/settings/settingsView.test.ts
@@ -2,12 +2,20 @@ import { describe, it, expect, vi } from "vitest"
 import { settingsPanel, getWebviewContent } from "./settingsView.js"
 import * as vscode from "vscode"
 
+const project = vi.hoisted(() => ({
+	settings: { get: async () => ({}) },
+	plugins: { get: async () => [] },
+}))
+const own = vi.hoisted(() => vi.fn(() => true))
+
 vi.mock("vscode", () => ({
 	window: {
 		createWebviewPanel: vi.fn().mockReturnValue({
+			dispose: vi.fn(),
+			onDidDispose: vi.fn(),
 			webview: {
 				html: "",
-				onDidReceiveMessage: vi.fn(),
+				onDidReceiveMessage: vi.fn(() => ({ dispose: vi.fn() })),
 				asWebviewUri: vi.fn().mockImplementation((uri: vscode.Uri) => uri),
 			},
 		}),
@@ -42,6 +50,21 @@ vi.mock("../state.js", () => ({
 	}),
 }))
 
+vi.mock("../project/projectRuntime.js", () => ({
+	getProjectRuntime: () => ({
+		activeProject: () => ({
+			path: "Users/username/happy-elephant.inlang",
+			project,
+			isCurrent: () => true,
+			own,
+			runTask: async <T>(task: () => Promise<T>) => ({
+				status: "completed" as const,
+				value: await task(),
+			}),
+		}),
+	}),
+}))
+
 describe("settingsPanel", () => {
 	it("should create a webview panel with the correct properties", async () => {
 		const mockContext = {
@@ -57,6 +80,7 @@ describe("settingsPanel", () => {
 				localResourceRoots: [expect.anything()],
 			})
 		)
+		expect(own).toHaveBeenCalledWith(expect.objectContaining({ dispose: expect.any(Function) }))
 	})
 })
 

--- a/src/utilities/settings/settingsView.ts
+++ b/src/utilities/settings/settingsView.ts
@@ -1,11 +1,14 @@
 import * as vscode from "vscode"
-import { state } from "../state.js"
 import { CONFIGURATION } from "../../configuration.js"
+import type { InlangProject } from "@inlang/sdk"
+import { getProjectRuntime, type ActiveProjectLease } from "../project/projectRuntime.js"
 
 export async function settingsPanel(args: { context: vscode.ExtensionContext }) {
+	const lease = getProjectRuntime<InlangProject>().activeProject()
+	if (!lease) return
 	const panel = vscode.window.createWebviewPanel(
 		"settingsPanel",
-		state().selectedProjectPath.split("/").pop() ?? "Settings",
+		lease.path.split("/").pop() ?? "Settings",
 		vscode.ViewColumn.One,
 		{
 			enableScripts: true,
@@ -16,22 +19,42 @@ export async function settingsPanel(args: { context: vscode.ExtensionContext }) 
 	panel.webview.html = await getWebviewContent({
 		context: args.context,
 		webview: panel.webview,
+		lease,
 	})
 
-	panel.webview.onDidReceiveMessage(async (message) => {
+	const messageSubscription = panel.webview.onDidReceiveMessage(async (message) => {
 		switch (message.command) {
 			case "setSettings":
-				state().project.settings.set(message.settings)
-				CONFIGURATION.EVENTS.ON_DID_SETTINGS_VIEW_CHANGE.fire()
+				const result = await lease.runTask(async () => {
+					await lease.project.settings.set(message.settings)
+				})
+				if (result.status === "completed") {
+					CONFIGURATION.EVENTS.ON_DID_SETTINGS_VIEW_CHANGE.fire()
+				}
 				break
 		}
 	})
+	panel.onDidDispose(() => messageSubscription.dispose())
+	if (
+		!lease.own({
+			dispose: () => {
+				messageSubscription.dispose()
+				panel.dispose()
+			},
+		})
+	) {
+		messageSubscription.dispose()
+		panel.dispose()
+	}
 }
 
 export async function getWebviewContent(args: {
 	context: vscode.ExtensionContext
 	webview: vscode.Webview
+	lease?: ActiveProjectLease<InlangProject>
 }): Promise<string> {
+	const lease = args.lease ?? getProjectRuntime<InlangProject>().activeProject()
+	if (!lease) return ""
 	const styleUri = args.webview.asWebviewUri(
 		vscode.Uri.joinPath(args.context.extensionUri, "assets", "settings-view.css")
 	)
@@ -44,8 +67,12 @@ export async function getWebviewContent(args: {
 		vscode.Uri.joinPath(args.context.extensionUri, "assets", "lit-html.js")
 	)
 
-	const settings = await state().project.settings.get()
-	const installedPlugins = await state().project.plugins.get()
+	const projectData = await lease.runTask(async () => ({
+		settings: await lease.project.settings.get(),
+		installedPlugins: await lease.project.plugins.get(),
+	}))
+	if (projectData.status !== "completed") return ""
+	const { settings, installedPlugins } = projectData.value
 	// TODO: Clarify how to derive validation rules from lix
 	// const installedMessageLintRules = state().project.installed.messageLintRules()
 

--- a/src/utilities/settings/statusBar.test.ts
+++ b/src/utilities/settings/statusBar.test.ts
@@ -1,100 +1,124 @@
 import * as vscode from "vscode"
-import { describe, it, expect, vi, beforeEach } from "vitest"
-import { statusBar, showStatusBar } from "./statusBar.js"
-import { state } from "../state.js"
-import { getSetting } from "./index.js"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import { CONFIGURATION } from "../../configuration.js"
+import { getPreviewLocale } from "../locale/getPreviewLocale.js"
+import { showStatusBar, statusBar } from "./statusBar.js"
 
-let lastStatusBarItem: any = undefined // Track the last status bar item created for testing
+const createdItems: Array<{
+	dispose: ReturnType<typeof vi.fn>
+	command?: string
+	text?: string
+	tooltip?: string
+	show: ReturnType<typeof vi.fn>
+}> = []
 
 vi.mock("vscode", () => ({
 	window: {
-		createStatusBarItem: vi.fn().mockImplementation(() => {
-			const statusBarMock = {
+		createStatusBarItem: vi.fn(() => {
+			const item = {
 				dispose: vi.fn(),
 				command: undefined,
 				text: undefined,
 				tooltip: undefined,
 				show: vi.fn(),
 			}
-			lastStatusBarItem = statusBarMock
-			return statusBarMock
+			createdItems.push(item)
+			return item
 		}),
 	},
-	StatusBarAlignment: {
-		Right: 1,
-	},
-	commands: {
-		registerCommand: vi.fn(),
-	},
-	EventEmitter: vi.fn().mockImplementation(() => ({
-		event: vi.fn(),
-	})),
-	CodeActionKind: {
-		QuickFix: vi.fn(),
+	StatusBarAlignment: { Right: 1 },
+	commands: { registerCommand: vi.fn() },
+	CodeActionKind: { QuickFix: "quickfix" },
+	EventEmitter: class {
+		fire = vi.fn()
+		event = vi.fn(() => ({ dispose: vi.fn() }))
 	},
 }))
 
-vi.mock("../state", () => ({
-	state: vi.fn().mockImplementation(() => ({
-		project: {
-			settings: {
-				get: vi.fn().mockResolvedValueOnce({ baseLocale: "en", locales: ["en", "de"] }),
-			},
-		},
-	})),
+vi.mock("../locale/getPreviewLocale.js", () => ({
+	getPreviewLocale: vi.fn(),
 }))
 
-vi.mock("./index", () => ({
-	getSetting: vi.fn().mockResolvedValueOnce("de"),
-}))
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+const activeContexts: vscode.ExtensionContext[] = []
+
+async function activateStatusBar() {
+	const context = { subscriptions: [] } as unknown as vscode.ExtensionContext
+	activeContexts.push(context)
+	await statusBar({ context })
+	return context
+}
 
 describe("statusBar", () => {
 	beforeEach(() => {
+		createdItems.length = 0
 		vi.clearAllMocks()
+		vi.mocked(getPreviewLocale).mockResolvedValue("en")
 	})
 
-	it("should subscribe to the appropriate events", async () => {
-		const context = {
-			subscriptions: { push: vi.fn() },
-		} as unknown as vscode.ExtensionContext
-		await statusBar({ context })
+	afterEach(() => {
+		for (const context of activeContexts.splice(0)) {
+			for (const subscription of context.subscriptions.toReversed()) subscription.dispose()
+		}
+	})
 
-		expect(context.subscriptions.push).toHaveBeenCalledTimes(2)
+	it("subscribes to project and locale changes and creates the initial item", async () => {
+		const context = await activateStatusBar()
+
+		expect(context.subscriptions).toHaveLength(3)
 		expect(CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.event).toHaveBeenCalled()
 		expect(CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.event).toHaveBeenCalled()
-	})
-})
-
-describe("showStatusBar", () => {
-	beforeEach(() => {
-		vi.clearAllMocks()
+		expect(createdItems.at(-1)?.text).toBe("Sherlock: en")
 	})
 
-	it("should create a new status bar item if it does not exist", async () => {
-		await showStatusBar()
-		expect(vscode.window.createStatusBarItem).toHaveBeenCalledTimes(1)
-	})
-
-	it("should dispose the existing status bar item if it exists", async () => {
-		await showStatusBar()
-		const disposeMock = lastStatusBarItem.dispose
+	it("replaces and disposes the existing item", async () => {
+		await activateStatusBar()
+		const firstItem = createdItems.at(-1)!
+		vi.mocked(getPreviewLocale).mockResolvedValueOnce("de")
 
 		await showStatusBar()
 
-		expect(disposeMock).toHaveBeenCalled()
+		expect(firstItem.dispose).toHaveBeenCalledTimes(1)
+		expect(createdItems.at(-1)?.text).toBe("Sherlock: de")
 	})
 
-	it("should handle the case when previewLocale is not available", async () => {
-		vi.mocked(getSetting).mockResolvedValueOnce("")
-		await showStatusBar()
-		expect(vscode.window.createStatusBarItem).toHaveBeenCalledTimes(1)
+	it("keeps only the newest concurrent update", async () => {
+		await activateStatusBar()
+		const slow = deferred<string>()
+		const fast = deferred<string>()
+		vi.mocked(getPreviewLocale)
+			.mockImplementationOnce(() => slow.promise)
+			.mockImplementationOnce(() => fast.promise)
+
+		const slowUpdate = showStatusBar()
+		const fastUpdate = showStatusBar()
+		fast.resolve("de")
+		await fastUpdate
+		slow.resolve("en")
+		await slowUpdate
+
+		expect(createdItems).toHaveLength(2)
+		expect(createdItems.at(-1)?.text).toBe("Sherlock: de")
 	})
 
-	it("should not set previewLocale if it's not in settings.locales", async () => {
-		vi.mocked(getSetting).mockResolvedValueOnce("es")
-		await showStatusBar()
+	it("does not recreate the item after disposal", async () => {
+		const context = await activateStatusBar()
+		const inFlight = deferred<string>()
+		vi.mocked(getPreviewLocale).mockImplementationOnce(() => inFlight.promise)
+		const update = showStatusBar()
 
-		expect(lastStatusBarItem.text).toBe("Sherlock: en")
+		context.subscriptions.at(-1)?.dispose()
+		inFlight.resolve("de")
+		await update
+
+		expect(createdItems).toHaveLength(1)
+		expect(createdItems[0]?.dispose).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/utilities/settings/statusBar.ts
+++ b/src/utilities/settings/statusBar.ts
@@ -3,34 +3,47 @@ import { CONFIGURATION } from "../../configuration.js"
 import { getPreviewLocale } from "../locale/getPreviewLocale.js"
 
 let statusBarItem: vscode.StatusBarItem | undefined = undefined
+let updateGeneration = 0
+let disposed = true
 
 export const statusBar = async (args: { context: vscode.ExtensionContext }) => {
+	disposed = false
 	// when project view changes, status bar
 	args.context.subscriptions.push(
 		CONFIGURATION.EVENTS.ON_DID_PROJECT_TREE_VIEW_CHANGE.event(() => {
-			showStatusBar()
+			void showStatusBar()
 		})
 	)
 	// when value of previewLanguageTag changes, update status bar
 	args.context.subscriptions.push(
 		CONFIGURATION.EVENTS.ON_DID_PREVIEW_LOCALE_CHANGE.event(() => {
-			showStatusBar()
+			void showStatusBar()
 		})
 	)
 
-	showStatusBar()
+	await showStatusBar()
+	args.context.subscriptions.push({
+		dispose: () => {
+			disposed = true
+			updateGeneration += 1
+			statusBarItem?.dispose()
+			statusBarItem = undefined
+		},
+	})
 }
 
 export const showStatusBar = async () => {
-	if (statusBarItem) {
-		statusBarItem.dispose()
-	}
-
+	const generation = ++updateGeneration
 	const previewLanguageTag = await getPreviewLocale()
+	if (disposed || generation !== updateGeneration) return
 
-	statusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
-	statusBarItem.command = "sherlock.previewLanguageTag"
-	statusBarItem.text = `Sherlock: ${previewLanguageTag}`
-	statusBarItem.tooltip = "Switch preview language"
-	statusBarItem.show()
+	const nextStatusBarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 100)
+	nextStatusBarItem.command = "sherlock.previewLanguageTag"
+	nextStatusBarItem.text = `Sherlock: ${previewLanguageTag}`
+	nextStatusBarItem.tooltip = "Switch preview language"
+	nextStatusBarItem.show()
+
+	const previousStatusBarItem = statusBarItem
+	statusBarItem = nextStatusBarItem
+	previousStatusBarItem?.dispose()
 }

--- a/src/utilities/state.ts
+++ b/src/utilities/state.ts
@@ -7,12 +7,13 @@ type State = {
 	/**
 	 * Inlang project
 	 */
-	project: InlangProject
+	project?: InlangProject
 	selectedProjectPath: string
 	projectsInWorkspace: Array<{ projectPath: string }>
 }
 
 let _state: State
+const proxiedProjects = new WeakSet<InlangProject>()
 
 /**
  * Set the state.
@@ -38,6 +39,20 @@ export function setProjectsInWorkspace(projectsInWorkspace: State["projectsInWor
 	}
 
 	if (_state.project) proxyPluginGetMethod(_state.project)
+}
+
+export function setActiveProject(active: { project: InlangProject; path: string } | undefined) {
+	_state = {
+		..._state,
+		project: active?.project,
+		selectedProjectPath: active?.path ?? "",
+	}
+
+	if (active) proxyPluginGetMethod(active.project)
+}
+
+export function prepareProject(project: InlangProject) {
+	proxyPluginGetMethod(project)
 }
 
 /**
@@ -71,6 +86,8 @@ export function safeState(): State | undefined {
  * Proxy the project.plugins.get method to apply migration automatically
  */
 function proxyPluginGetMethod(project: InlangProject) {
+	if (proxiedProjects.has(project)) return
+	proxiedProjects.add(project)
 	const originalGet = project.plugins.get
 
 	// Replace the get function with our proxy
@@ -81,7 +98,7 @@ function proxyPluginGetMethod(project: InlangProject) {
 		const mutablePlugins = [...plugins]
 
 		// Apply the migration logic to plugins
-		await migrateAddCustomApi(mutablePlugins)
+		await migrateAddCustomApi(mutablePlugins, project)
 
 		return mutablePlugins // Return the migrated plugins
 	}
@@ -90,9 +107,7 @@ function proxyPluginGetMethod(project: InlangProject) {
 /**
  * Migrate the addCustomApi method to meta for a list of plugins.
  */
-async function migrateAddCustomApi(plugins: InlangPlugin[]): Promise<void> {
-	const project = state().project
-
+async function migrateAddCustomApi(plugins: InlangPlugin[], project: InlangProject): Promise<void> {
 	// Migrate each plugin
 	for (const plugin of plugins) {
 		// If the plugin has an addCustomApi function and meta is not set

--- a/test/specs/project-session-lifecycle.e2e.test.ts
+++ b/test/specs/project-session-lifecycle.e2e.test.ts
@@ -1,0 +1,70 @@
+import { browser, expect } from "@wdio/globals"
+import vscode from "vscode"
+import {} from "wdio-vscode-service"
+
+describe("Project session lifecycle", () => {
+	it("keeps extension registration stable across repeated project reloads", async () => {
+		const result = await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+			await extension?.activate()
+			const workspaceFolder = vscodeApi.workspace.workspaceFolders?.[0]
+			if (!workspaceFolder) throw new Error("Expected the E2E workspace to be open")
+			const document = await vscodeApi.workspace.openTextDocument(
+				vscodeApi.Uri.joinPath(workspaceFolder.uri, "src/app.js")
+			)
+			const countSherlockCodeActions = async () => {
+				const actions = await vscodeApi.commands.executeCommand<vscode.CodeAction[]>(
+					"vscode.executeCodeActionProvider",
+					document.uri,
+					new vscodeApi.Range(0, 0, 0, 1)
+				)
+				return actions?.filter((action) => action.title === "Sherlock: Extract Message").length ?? 0
+			}
+			const codeActionCounts = [await countSherlockCodeActions()]
+			const firstReload = await vscodeApi.commands.executeCommand<string>("sherlock.reloadProject")
+			codeActionCounts.push(await countSherlockCodeActions())
+			const secondReload = await vscodeApi.commands.executeCommand<string>("sherlock.reloadProject")
+			codeActionCounts.push(await countSherlockCodeActions())
+
+			return {
+				active: extension?.isActive ?? false,
+				hasPrivateContextExport: extension?.exports?.context !== undefined,
+				codeActionCounts,
+				firstReload,
+				secondReload,
+			}
+		})
+
+		expect(result).toEqual({
+			active: true,
+			hasPrivateContextExport: false,
+			codeActionCounts: [1, 1, 1],
+			firstReload: "committed",
+			secondReload: "committed",
+		})
+	})
+
+	it("deactivates cleanly when VS Code restarts the extension host", async () => {
+		await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			await vscodeApi.extensions.getExtension("inlang.vs-code-extension")?.activate()
+			setTimeout(() => {
+				void vscodeApi.commands.executeCommand("workbench.action.restartExtensionHost")
+			}, 0)
+		})
+
+		await browser.waitUntil(
+			async () => {
+				try {
+					return await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+						const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+						await extension?.activate()
+						return extension?.isActive ?? false
+					})
+				} catch {
+					return false
+				}
+			},
+			{ timeout: 60_000, interval: 500 }
+		)
+	})
+})

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -206,8 +206,11 @@ export const config: Options.Testrunner = {
 	 * @param  {object} specs    specs to be run in the worker process
 	 * @param  {number} retries  number of retries used
 	 */
-	// onWorkerEnd: function (cid, exitCode, specs, retries) {
-	// },
+	onWorkerEnd: function () {
+		if (providedWorkspacePath) return
+		fs.rmSync(e2eWorkspacePath, { recursive: true, force: true })
+		fs.cpSync(fixtureWorkspacePath, e2eWorkspacePath, { recursive: true })
+	},
 	/**
 	 * Gets executed just before initialising the webdriver session and test framework. It allows you
 	 * to manipulate configurations depending on the capability or spec.


### PR DESCRIPTION
## What changed

- register global VS Code commands, views, and providers once during activation
- add one runtime owner for loading, replacing, and closing the active inlang project
- move project-specific resources under the active session, including diagnostics, decorations, editor state, polling, and the existing filesystem watcher
- route initial loading, reloads, and project selection through the same replacement flow
- prevent stale loads and callbacks from updating a newer project
- wait for active project work before disposing resources and closing the project
- add unit and extension-host coverage for reloads, failures, races, switching, and deactivation

This is the first implementation step from [#212](https://github.com/opral/sherlock/issues/212). It focuses only on project/session ownership. Plugin-driven file watching will follow in a separate PR.

## Why

Reloading previously entered the extension setup again, while project selection loaded a project directly into shared state. That mixed two different lifetimes:

- global VS Code registrations, which should exist once per extension activation
- project resources, which should be replaced whenever the active project changes

As a result, a reload or quick project switch could leave old listeners running, duplicate registrations, or allow a slower load to replace a newer selection.

### Before

Reloading entered extension setup again, while project selection took a separate path through shared state.

```mermaid
flowchart LR
    beforeActivation["Extension activation"] --> beforeRegistrations["Register commands, views, and providers"]
    beforeReload["Reload project"] --> beforeActivation
    beforeSelect["Select project"] --> beforeSharedState["Replace shared project state directly"]
    beforeSharedState -.-> beforeOldWork["Old project work may still be running"]
```

### After

Activation owns global VS Code features. Reload and selection both ask the project runtime to replace one self-contained session.

```mermaid
flowchart LR
    afterActivation["Extension activation"] --> afterRegistrations["Register global VS Code features once"]
    afterRegistrations --> afterRuntime["Create project runtime"]
    afterReload["Reload project"] --> afterRuntime
    afterSelect["Select project"] --> afterRuntime
    afterRuntime --> afterSession["Replace active project session"]
```

The extension context owns long-lived registrations. The active session owns only the resources tied to its inlang project:

```mermaid
flowchart TD
    ownerExtension["Extension context"] --> ownerGlobal["Global commands, views, and providers"]
    ownerExtension --> ownerRuntime["Project runtime"]
    ownerRuntime --> ownerSession["Active project session"]

    ownerSession --> ownerProject["Inlang project"]
    ownerSession --> ownerUi["Diagnostics, decorations, and editor state"]
    ownerSession --> ownerPolling["Message polling"]
    ownerSession --> ownerWatcher["Existing filesystem watcher"]
```

## How project replacement works

The current session stays active while the next project is loaded and prepared. The candidate is published only when it is ready and is still the newest request.

```mermaid
sequenceDiagram
    participant User
    participant Runtime
    participant Current as Current session
    participant Next as Candidate session
    participant UI

    User->>Runtime: Reload or select project
    Runtime->>Next: Load and prepare

    alt Loading or setup fails
        Runtime->>Next: Dispose and close
        Note over Current: Current session stays active
    else A newer request exists
        Runtime->>Next: Dispose stale candidate
        Note over Current: Newest request decides the active session
    else Candidate is ready
        Runtime->>Next: Publish as active
        Runtime->>Current: Stop new callbacks
        Runtime->>Current: Wait for running work
        Runtime->>Current: Dispose and close once
        Runtime->>UI: Send one project-change event
    end
```

Project-bound async work runs through a session lease. If the session becomes inactive before that work finishes, its result is ignored. This prevents old diagnostics, decorations, watcher callbacks, commands, or message queries from refreshing the UI for a different project.

A successful replacement sends one project-change event. The messages view, decorations, diagnostics, project tree, and error tree all refresh from that event.

## Failure and race behavior

| Situation | Result |
| --- | --- |
| Loading the candidate fails | The current session stays active |
| Preparing candidate resources fails | Candidate resources are disposed and its project is closed |
| A slow load finishes after a newer selection | The stale candidate is closed and cannot become active |
| Old async work finishes after replacement | Its result cannot update the current UI |
| An old resource fails during disposal | The replacement remains active and the cleanup error is reported |
| VS Code deactivates during a load | The candidate is closed and cannot be published |
| VS Code deactivates normally | The active session finishes its work, disposes, and closes exactly once |

## Existing filesystem watcher

Filesystem watching still stays in Sherlock, as agreed in [#212](https://github.com/opral/sherlock/issues/212#issuecomment-4993832784). This PR does not change the watcher to plugin-provided paths yet.

The existing watcher now belongs to its project session:

- it captures the project it was created for instead of reading a later global selection
- its hashes, message keys, debounce state, and running work are session-local
- disposal cancels queued callbacks and waits for callbacks already running
- watcher results refresh the UI only while their session is active

Support for `toBeImportedFiles()` and formats such as i18next remains a follow-up.

## Compatibility notes

- the deprecated `getSelectedBundleByBundleIdOrAlias` helper is not used; exact bundle lookup uses the project-owned `selectBundleById` query
- global VS Code registrations are no longer recreated on reload
- same-path reloads replace polling by project identity, so a view cannot remain attached to the closed project
- the current inlang/Kysely APIs do not expose cancellation for a query already in progress, so teardown stops new work and waits for the active query before closing SQLite
- no persistence format, project format, or user-facing command behavior is intentionally changed

## Validation

- `tsc --noEmit`
- `pnpm run build`
- `pnpm test` — 195 passed, 2 skipped, 2 todo
- `pnpm run test:e2e` — 7 spec files and 11 tests passed together
  - two consecutive project reloads
  - real extension-host restart and deactivation
- VSIX packaging
- installed and tested the VSIX in VS Code
- verified reload and project use manually
- Prettier on all changed source and test files
- `git diff --check`

The E2E workspace is restored after each worker. Closing a project can persist its in-memory state, so sharing an already-mutated fixture made later specs depend on earlier workers.

## Review guide

The branch is split into three commits:

1. `refactor: introduce project session lifecycle`
   - lifecycle and runtime modules
   - replacement, rollback, race, lease, and disposal tests
2. `refactor: bind project resources to active sessions`
   - VS Code integration
   - project-owned commands, views, diagnostics, decorations, polling, and watcher work
3. `test: verify project lifecycle in extension host`
   - repeated reload coverage
   - real extension restart coverage
   - isolated E2E workspaces

## Out of scope

- plugin-driven watch paths through `toBeImportedFiles()`
- i18next watcher coverage
- persistence changes
- editor, settings, or extension-view redesign
- unrelated cleanup and issue fixes

Part of #212.
