### PR TITLE
Move project session setup into one place

### DIFF
--- a/src/main.test.ts
+++ b/src/main.test.ts
@@ -11,7 +11,7 @@ import {
 import { state } from "./utilities/state.js"
 import { handleError } from "./utilities/utils.js"
 import { gettingStartedView } from "./utilities/getting-started/gettingStarted.js"
-import { loadProjectFromDirectory, saveProjectToDirectory } from "@inlang/sdk"
+import { saveProjectToDirectory } from "@inlang/sdk"
 import { closestInlangProject } from "./utilities/project/closestInlangProject.js"
 import { projectView } from "./utilities/project/project.js"
 import { messageView } from "./utilities/messages/messages.js"
@@ -19,13 +19,15 @@ import { errorView } from "./utilities/errors/errors.js"
 import { recommendationBannerView } from "./utilities/recommendation/recommendation.js"
 import { getProjectRuntime } from "./utilities/project/projectRuntime.js"
 import { CONFIGURATION } from "./configuration.js"
-import {
-	createResourceLoadTracker,
-	runWithPluginResourceWrite,
-	setupPluginResourceWatcher,
-} from "./utilities/fs/pluginResourceWatcher.js"
+import { runWithPluginResourceWrite } from "./utilities/fs/pluginResourceWatcher.js"
+import { createProjectSessionEnvironment } from "./utilities/project/projectSessionEnvironment.js"
 
 const createOpenEditorViewCallback = vi.hoisted(() => vi.fn(() => vi.fn()))
+const environment = vi.hoisted(() => ({
+	mappedFs: { mapped: true },
+	runtime: undefined as any,
+	create: vi.fn(),
+}))
 
 vi.mock("vscode", () => ({
 	version: "1.90.0",
@@ -125,7 +127,11 @@ vi.mock("./utilities/messages/messages.js", () => ({
 }))
 
 vi.mock("./utilities/fs/createFileSystemMapper.js", () => ({
-	createFileSystemMapper: vi.fn(),
+	createFileSystemMapper: vi.fn(() => environment.mappedFs),
+}))
+
+vi.mock("./utilities/project/projectSessionEnvironment.js", () => ({
+	createProjectSessionEnvironment: environment.create,
 }))
 
 vi.mock("./utilities/getting-started/gettingStarted.js", () => ({
@@ -156,14 +162,11 @@ vi.mock("./diagnostics/linterDiagnostics.js", () => ({
 }))
 
 vi.mock("./utilities/fs/pluginResourceWatcher.js", () => ({
-	createResourceLoadTracker: vi.fn((fs) => ({ fs, snapshot: new Map() })),
 	runWithPluginResourceWrite: vi.fn(async (_project, write) => write(vi.fn())),
-	setupPluginResourceWatcher: vi.fn(),
 }))
 
 vi.mock("@inlang/sdk", () => ({
 	saveProjectToDirectory: vi.fn(),
-	loadProjectFromDirectory: vi.fn(),
 }))
 
 describe("discoverProjectsInWorkspace", () => {
@@ -176,6 +179,13 @@ describe("discoverProjectsInWorkspace", () => {
 	beforeEach(async () => {
 		await deactivate()
 		vi.clearAllMocks()
+		environment.runtime = {
+			replaceProject: vi.fn(async () => ({ status: "committed" as const })),
+			activeProject: vi.fn(() => undefined),
+			lastRequestedProjectPath: vi.fn(() => undefined),
+			dispose: vi.fn(async () => undefined),
+		}
+		environment.create.mockReturnValue(environment.runtime)
 		;(
 			vscode.workspace as unknown as { workspaceFolders: vscode.WorkspaceFolder[] }
 		).workspaceFolders = [workspaceFolder]
@@ -228,27 +238,7 @@ describe("discoverProjectsInWorkspace", () => {
 	})
 
 	it("registers global views once while replacing only the project session", async () => {
-		const firstWatcherDispose = vi.fn()
-		const secondWatcherDispose = vi.fn()
-		let watcherInstall = 0
-		vi.mocked(setupPluginResourceWatcher).mockImplementation(async ({ session }) => {
-			session.own({
-				dispose: watcherInstall++ === 0 ? firstWatcherDispose : secondWatcherDispose,
-			})
-			return []
-		})
-		const firstProject = {
-			plugins: { get: vi.fn(async () => []) },
-			settings: { get: vi.fn(async () => ({ locales: [] })) },
-			errors: { get: vi.fn(async () => []) },
-			close: vi.fn(async () => undefined),
-		}
-		const reloadedProject = {
-			plugins: { get: vi.fn(async () => []) },
-			settings: { get: vi.fn(async () => ({ locales: [] })) },
-			errors: { get: vi.fn(async () => []) },
-			close: vi.fn(async () => undefined),
-		}
+		const messageController = { bindProject: vi.fn() }
 		const context = {
 			subscriptions: [],
 			extensionUri: { fsPath: "/extension" },
@@ -257,14 +247,23 @@ describe("discoverProjectsInWorkspace", () => {
 		vi.mocked(closestInlangProject).mockResolvedValueOnce({
 			projectPath: "/workspace/project.inlang",
 		} as any)
-		vi.mocked(loadProjectFromDirectory)
-			.mockResolvedValueOnce(firstProject as any)
-			.mockResolvedValueOnce(reloadedProject as any)
+		vi.mocked(messageView).mockResolvedValueOnce(messageController as any)
 
 		await activate(context)
 		await getProjectRuntime().replaceProject("/workspace/project.inlang")
 
-		expect(createResourceLoadTracker).toHaveBeenCalledTimes(2)
+		expect(createProjectSessionEnvironment).toHaveBeenCalledWith({
+			fileSystem: environment.mappedFs,
+			messageView: messageController,
+		})
+		expect(environment.runtime.replaceProject).toHaveBeenNthCalledWith(
+			1,
+			"/workspace/project.inlang"
+		)
+		expect(environment.runtime.replaceProject).toHaveBeenNthCalledWith(
+			2,
+			"/workspace/project.inlang"
+		)
 		expect(projectView).toHaveBeenCalledTimes(1)
 		expect(messageView).toHaveBeenCalledTimes(1)
 		expect(messageView).toHaveBeenCalledWith({
@@ -278,52 +277,23 @@ describe("discoverProjectsInWorkspace", () => {
 		})
 		expect(errorView).toHaveBeenCalledTimes(1)
 		expect(recommendationBannerView).toHaveBeenCalledTimes(1)
-		expect(firstProject.close).toHaveBeenCalledTimes(1)
-		expect(setupPluginResourceWatcher).toHaveBeenCalledTimes(2)
-		expect(vi.mocked(setupPluginResourceWatcher).mock.calls[0]?.[0].loadSnapshot).toBe(
-			vi.mocked(createResourceLoadTracker).mock.results[0]?.value.snapshot
-		)
-		expect(vi.mocked(setupPluginResourceWatcher).mock.calls[1]?.[0].loadSnapshot).toBe(
-			vi.mocked(createResourceLoadTracker).mock.results[1]?.value.snapshot
-		)
-		expect(firstWatcherDispose).toHaveBeenCalledOnce()
-		const firstCodeActionProvider = vi.mocked(vscode.languages.registerCodeActionsProvider).mock
-			.results[0]?.value as vscode.Disposable
-		expect(firstCodeActionProvider.dispose).toHaveBeenCalledTimes(1)
-		expect(vi.mocked(firstCodeActionProvider.dispose).mock.invocationCallOrder[0]).toBeLessThan(
-			firstProject.close.mock.invocationCallOrder[0]!
-		)
-		expect(firstWatcherDispose.mock.invocationCallOrder[0]).toBeLessThan(
-			firstProject.close.mock.invocationCallOrder[0]!
-		)
-		expect(firstProject.close.mock.invocationCallOrder[0]).toBeLessThan(
-			vi.mocked(setupPluginResourceWatcher).mock.invocationCallOrder[1]!
-		)
-		expect(reloadedProject.close).not.toHaveBeenCalled()
-		expect(CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire).toHaveBeenCalledTimes(2)
 
 		await deactivate()
 		await deactivate()
-		expect(secondWatcherDispose).toHaveBeenCalledOnce()
-		expect(reloadedProject.close).toHaveBeenCalledTimes(1)
+		expect(environment.runtime.dispose).toHaveBeenCalledTimes(1)
 	})
 
 	it("keeps global views and the runtime available after the initial project load fails", async () => {
 		const loadError = new Error("plugin failed to load")
-		const recoveredProject = {
-			plugins: { get: vi.fn(async () => []) },
-			settings: { get: vi.fn(async () => ({ locales: [] })) },
-			errors: { get: vi.fn(async () => []) },
-			close: vi.fn(async () => undefined),
-		}
 		const context = { subscriptions: [] } as unknown as vscode.ExtensionContext
 		vi.mocked(fg.async).mockResolvedValueOnce(["/workspace/project.inlang"])
 		vi.mocked(closestInlangProject).mockResolvedValueOnce({
 			projectPath: "/workspace/project.inlang",
 		} as any)
-		vi.mocked(loadProjectFromDirectory)
-			.mockRejectedValueOnce(loadError)
-			.mockResolvedValueOnce(recoveredProject as any)
+		environment.runtime.replaceProject
+			.mockResolvedValueOnce({ status: "failed", error: loadError })
+			.mockResolvedValueOnce({ status: "committed" })
+		environment.runtime.lastRequestedProjectPath.mockReturnValue("/workspace/project.inlang")
 
 		await activate(context)
 
@@ -334,7 +304,7 @@ describe("discoverProjectsInWorkspace", () => {
 		await expect(getProjectRuntime().replaceProject("/workspace/project.inlang")).resolves.toEqual({
 			status: "committed",
 		})
-		expect(state().project).toBe(recoveredProject)
+		expect(environment.runtime.replaceProject).toHaveBeenCalledTimes(2)
 	})
 
 	it("marks successful project exports as owned resource writes", async () => {

--- a/src/main.ts
+++ b/src/main.ts
@@ -2,19 +2,11 @@ import * as vscode from "vscode"
 import { handleError } from "./utilities/utils.js"
 import { CONFIGURATION } from "./configuration.js"
 import { projectView } from "./utilities/project/project.js"
-import {
-	prepareProject,
-	setActiveProject,
-	setProjectsInWorkspace,
-	state,
-} from "./utilities/state.js"
-import { messagePreview } from "./decorations/messagePreview.js"
-import { ExtractMessage } from "./actions/extractMessage.js"
+import { setProjectsInWorkspace, state } from "./utilities/state.js"
 import { errorView } from "./utilities/errors/errors.js"
 import { messageView, type MessageViewController } from "./utilities/messages/messages.js"
 import { createFileSystemMapper, type FileSystem } from "./utilities/fs/createFileSystemMapper.js"
 import fs from "node:fs/promises"
-import * as nodeFs from "node:fs"
 import { gettingStartedView } from "./utilities/getting-started/gettingStarted.js"
 import { closestInlangProject } from "./utilities/project/closestInlangProject.js"
 import { recommendationBannerView } from "./utilities/recommendation/recommendation.js"
@@ -22,28 +14,17 @@ import { capture } from "./services/telemetry/index.js"
 import packageJson from "../package.json" with { type: "json" }
 import { statusBar } from "./utilities/settings/statusBar.js"
 import fg from "fast-glob"
-import {
-	loadProjectFromDirectory,
-	saveProjectToDirectory,
-	type IdeExtensionConfig,
-	type InlangProject,
-} from "@inlang/sdk"
+import { saveProjectToDirectory, type InlangProject } from "@inlang/sdk"
 import type { ActiveProjectLease } from "./utilities/project/projectRuntime.js"
 import path from "node:path"
-import { linterDiagnostics } from "./diagnostics/linterDiagnostics.js"
-import {
-	createResourceLoadTracker,
-	runWithPluginResourceWrite,
-	setupPluginResourceWatcher,
-} from "./utilities/fs/pluginResourceWatcher.js"
+import { runWithPluginResourceWrite } from "./utilities/fs/pluginResourceWatcher.js"
 import { trackFileSystemMutations } from "./utilities/fs/trackFileSystemMutations.js"
-import { deactivateBeforeClose } from "./utilities/project/projectSession.js"
 import {
-	createProjectRuntime,
 	disposeProjectRuntime,
 	getProjectRuntime,
 	installProjectRuntime,
 } from "./utilities/project/projectRuntime.js"
+import { createProjectSessionEnvironment } from "./utilities/project/projectSessionEnvironment.js"
 //import { initErrorMonitoring } from "./services/error-monitoring/implementation.js"
 
 type JsonObject = Record<string, unknown>
@@ -85,61 +66,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 				subscriptions: context.subscriptions,
 			})
 		}
-		const resourceLoadSnapshots = new WeakMap<
-			InlangProject,
-			ReturnType<typeof createResourceLoadTracker>["snapshot"]
-		>()
-		const runtime = createProjectRuntime({
-			loadProject: async (projectPath) => {
-				const loadTracker = createResourceLoadTracker(nodeFs)
-				const project = await loadProjectFromDirectory({ path: projectPath, fs: loadTracker.fs })
-				resourceLoadSnapshots.set(project, loadTracker.snapshot)
-				prepareProject(project)
-				return project
-			},
-			publishActiveSession: (session) =>
-				setActiveProject(session ? { project: session.project, path: session.path } : undefined),
-			prepareSession: async (session, resources) => {
-				const ideExtension = (await session.project.plugins.get()).find(
-					(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
-				)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
-				const documentSelectors: vscode.DocumentSelector = [
-					{ language: "javascript", pattern: `!${CONFIGURATION.FILES.PROJECT}` },
-					...(ideExtension?.documentSelectors ?? []),
-				]
-				return {
-					activate: () => {
-						resources.push(
-							deactivateBeforeClose(
-								vscode.languages.registerCodeActionsProvider(
-									documentSelectors,
-									new ExtractMessage(),
-									{ providedCodeActionKinds: ExtractMessage.providedCodeActionKinds }
-								)
-							)
-						)
-						messagePreview({ subscriptions: resources, session })
-						void linterDiagnostics({ subscriptions: resources, fs: mappedFs, session })
-						if (messageController) {
-							resources.push(deactivateBeforeClose(messageController.bindProject(session)))
-						}
-					},
-					afterPreviousDisposed: async () => {
-						await setupPluginResourceWatcher({
-							session,
-							loadSnapshot: resourceLoadSnapshots.get(session.project),
-							onError: handleError,
-						})
-						await session
-							.runTask(async () => {
-								await handleInlangErrors(session.project)
-							})
-							.catch(handleError)
-					},
-				}
-			},
-			onDidReplaceSession: notifyProjectChanged,
-			onError: (error) => handleError(error),
+		const runtime = createProjectSessionEnvironment({
+			fileSystem: mappedFs,
+			messageView: messageController,
 		})
 		installProjectRuntime(runtime)
 		context.subscriptions.push({ dispose: () => void disposeProjectRuntime() })
@@ -218,19 +147,8 @@ async function registerGlobalViews(args: {
 	await statusBar(args)
 }
 
-function notifyProjectChanged() {
-	CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire(undefined)
-}
-
 export async function deactivate() {
 	await disposeProjectRuntime()
-}
-
-async function handleInlangErrors(project: Awaited<ReturnType<typeof loadProjectFromDirectory>>) {
-	const inlangErrors = (await project.errors.get()) || []
-	if (inlangErrors.length > 0) {
-		console.error("Extension errors (Sherlock):", inlangErrors)
-	}
 }
 
 export async function discoverProjectsInWorkspace(args: {

--- a/src/utilities/project/projectRuntime.test.ts
+++ b/src/utilities/project/projectRuntime.test.ts
@@ -1,85 +1,41 @@
 import { afterEach, describe, expect, it, vi } from "vitest"
 import {
-	createProjectRuntime,
 	disposeProjectRuntime,
 	getProjectRuntime,
 	installProjectRuntime,
+	type ProjectRuntime,
 } from "./projectRuntime.js"
-
-function fakeProject(name: string) {
-	return {
-		name,
-		close: vi.fn(async () => undefined),
-	}
-}
-
-const prepareSession = vi.fn(async () => ({ activate: () => undefined }))
 
 afterEach(async () => {
 	await disposeProjectRuntime()
 })
 
-describe("project runtime", () => {
-	it("is the single installed lifecycle owner and disposes idempotently", async () => {
-		const project = fakeProject("active")
-		const runtime = createProjectRuntime({
-			loadProject: vi.fn(async () => project),
-			prepareSession,
-			publishActiveSession: vi.fn(),
+describe("project runtime registry", () => {
+	it("installs a single runtime and disposes it idempotently", async () => {
+		let finishDisposal!: () => void
+		const disposal = new Promise<void>((resolve) => {
+			finishDisposal = resolve
 		})
+		const runtime: ProjectRuntime<{ close(): Promise<void> }> = {
+			replaceProject: vi.fn(async () => ({ status: "committed" as const })),
+			activeProject: vi.fn(() => undefined),
+			lastRequestedProjectPath: vi.fn(() => undefined),
+			dispose: vi.fn(() => disposal),
+		}
 
 		installProjectRuntime(runtime)
 		expect(getProjectRuntime()).toBe(runtime)
 		expect(() => installProjectRuntime(runtime)).toThrow("already initialized")
 
-		await runtime.replaceProject("/active.inlang")
-		await disposeProjectRuntime()
-		await disposeProjectRuntime()
-
-		expect(project.close).toHaveBeenCalledTimes(1)
+		const firstDisposal = disposeProjectRuntime()
+		const secondDisposal = disposeProjectRuntime()
+		expect(firstDisposal).toBe(secondDisposal)
+		expect(runtime.dispose).toHaveBeenCalledTimes(1)
 		expect(() => getProjectRuntime()).toThrow("not initialized")
-	})
 
-	it("returns a lease that becomes stale after project replacement", async () => {
-		const first = fakeProject("first")
-		const second = fakeProject("second")
-		const runtime = createProjectRuntime({
-			loadProject: vi.fn().mockResolvedValueOnce(first).mockResolvedValueOnce(second),
-			prepareSession,
-			publishActiveSession: vi.fn(),
-		})
-
-		await runtime.replaceProject("/first.inlang")
-		const lease = runtime.activeProject()
-		const resource = { dispose: vi.fn() }
-		expect(lease?.own(resource)).toBe(true)
-		expect(lease?.project).toBe(first)
-		await runtime.replaceProject("/second.inlang")
-
-		expect(lease?.isCurrent()).toBe(false)
-		expect(resource.dispose).toHaveBeenCalledWith("replacement")
-		expect(lease?.own({ dispose: vi.fn() })).toBe(false)
-		expect(runtime.activeProject()?.project).toBe(second)
-		const activeResource = { dispose: vi.fn() }
-		expect(runtime.activeProject()?.own(activeResource)).toBe(true)
-
-		await runtime.dispose()
-
-		expect(activeResource.dispose).toHaveBeenCalledWith("shutdown")
-	})
-
-	it("remembers a failed initial project path for recovery", async () => {
-		const runtime = createProjectRuntime({
-			loadProject: vi.fn(async () => Promise.reject(new Error("load failed"))),
-			prepareSession,
-			publishActiveSession: vi.fn(),
-		})
-
-		await expect(runtime.replaceProject("/failed.inlang")).resolves.toMatchObject({
-			status: "failed",
-		})
-
-		expect(runtime.activeProject()).toBeUndefined()
-		expect(runtime.lastRequestedProjectPath()).toBe("/failed.inlang")
+		finishDisposal()
+		await firstDisposal
+		await disposeProjectRuntime()
+		expect(runtime.dispose).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/utilities/project/projectRuntime.ts
+++ b/src/utilities/project/projectRuntime.ts
@@ -1,9 +1,6 @@
 import {
-	createProjectSessionLifecycle,
 	type Disposable,
-	type ProjectSession,
 	type ProjectReplacementResult,
-	type PreparedProjectSession,
 	type ProjectTaskResult,
 } from "./projectSession.js"
 
@@ -22,53 +19,6 @@ export type ProjectRuntime<Project extends CloseableProject> = {
 	activeProject(): ActiveProjectLease<Project> | undefined
 	lastRequestedProjectPath(): string | undefined
 	dispose(): Promise<void>
-}
-
-export function createProjectRuntime<Project extends CloseableProject>(args: {
-	loadProject(path: string): Promise<Project>
-	prepareSession(
-		session: ProjectSession<Project>,
-		resources: Disposable[]
-	): Promise<PreparedProjectSession>
-	publishActiveSession(session: ProjectSession<Project> | undefined): void
-	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
-	onError?(
-		error: unknown,
-		phase: "cleanup" | "activation" | "notification" | "reconciliation"
-	): void
-}): ProjectRuntime<Project> {
-	let activeSession: ProjectSession<Project> | undefined
-	let lastRequestedProjectPath: string | undefined
-	const lifecycle = createProjectSessionLifecycle({
-		loadProject: args.loadProject,
-		prepareSession: args.prepareSession,
-		setActiveSession: (session) => {
-			args.publishActiveSession(session)
-			activeSession = session
-		},
-		onDidReplaceSession: args.onDidReplaceSession,
-		onError: args.onError,
-	})
-
-	return {
-		replaceProject(path) {
-			lastRequestedProjectPath = path
-			return lifecycle.replaceProject(path)
-		},
-		activeProject() {
-			const session = activeSession
-			if (!session) return undefined
-			return {
-				path: session.path,
-				project: session.project,
-				isCurrent: () => activeSession === session,
-				own: (resource) => session.own(resource),
-				runTask: (task) => session.runTask(task),
-			}
-		},
-		lastRequestedProjectPath: () => lastRequestedProjectPath,
-		dispose: lifecycle.dispose,
-	}
 }
 
 let installedRuntime: ProjectRuntime<CloseableProject> | undefined

--- a/src/utilities/project/projectSessionEnvironment.test.ts
+++ b/src/utilities/project/projectSessionEnvironment.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest"
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest"
 import type { InlangProject } from "@inlang/sdk"
 import crypto from "node:crypto"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
@@ -176,6 +176,10 @@ beforeEach(() => {
 	host.linterDiagnostics.mockResolvedValue(undefined)
 	host.watchers.length = 0
 	host.fileContents.clear()
+})
+
+afterEach(() => {
+	vi.useRealTimers()
 })
 
 describe("project session environment", () => {

--- a/src/utilities/project/projectSessionEnvironment.test.ts
+++ b/src/utilities/project/projectSessionEnvironment.test.ts
@@ -6,10 +6,20 @@ const host = vi.hoisted(() => ({
 	loadProjectFromDirectory: vi.fn(),
 	prepareProject: vi.fn(),
 	setActiveProject: vi.fn(),
+	registerCodeActionsProvider: vi.fn(),
+	messagePreview: vi.fn(),
+	linterDiagnostics: vi.fn(),
+	handleError: vi.fn(),
 	createResourceLoadTracker: vi.fn(() => ({
 		fs: { tracked: true },
 		snapshot: vi.fn(),
 	})),
+}))
+
+vi.mock("vscode", () => ({
+	languages: {
+		registerCodeActionsProvider: host.registerCodeActionsProvider,
+	},
 }))
 
 vi.mock("@inlang/sdk", () => ({
@@ -25,12 +35,45 @@ vi.mock("../fs/pluginResourceWatcher.js", () => ({
 	createResourceLoadTracker: host.createResourceLoadTracker,
 }))
 
+vi.mock("../../decorations/messagePreview.js", () => ({
+	messagePreview: host.messagePreview,
+}))
+
+vi.mock("../../diagnostics/linterDiagnostics.js", () => ({
+	linterDiagnostics: host.linterDiagnostics,
+}))
+
+vi.mock("../../actions/extractMessage.js", () => ({
+	ExtractMessage: class {
+		static providedCodeActionKinds = ["quickfix"]
+	},
+}))
+
+vi.mock("../../configuration.js", () => ({
+	CONFIGURATION: {
+		FILES: { PROJECT: "project.inlang/settings.json" },
+	},
+}))
+
+vi.mock("../utils.js", () => ({
+	handleError: host.handleError,
+}))
+
 import { createProjectSessionEnvironment } from "./projectSessionEnvironment.js"
 
-function fakeProject(name: string) {
+function fakeProject(name: string, documentSelectors: Array<{ language: string }> = []) {
 	return {
 		name,
 		close: vi.fn(async () => undefined),
+		plugins: {
+			get: vi.fn(async () => [
+				{
+					meta: {
+						"app.inlang.ideExtension": { documentSelectors },
+					},
+				},
+			]),
+		},
 	} as unknown as InlangProject
 }
 
@@ -44,12 +87,19 @@ function deferred<T>() {
 
 const fileSystem = {} as FileSystem
 
+function disposable(onDispose: () => unknown = vi.fn()) {
+	return { deactivate: onDispose, dispose: onDispose }
+}
+
 beforeEach(() => {
 	vi.clearAllMocks()
 	host.createResourceLoadTracker.mockReturnValue({
 		fs: { tracked: true },
 		snapshot: vi.fn(),
 	})
+	host.registerCodeActionsProvider.mockImplementation(() => disposable())
+	host.messagePreview.mockImplementation(() => undefined)
+	host.linterDiagnostics.mockResolvedValue(undefined)
 })
 
 describe("project session environment", () => {
@@ -135,5 +185,139 @@ describe("project session environment", () => {
 		expect(host.setActiveProject).toHaveBeenLastCalledWith(undefined)
 		expect(project.close).toHaveBeenCalledTimes(1)
 		expect(runtime.activeProject()).toBeUndefined()
+	})
+
+	it("registers code actions for selectors read after project preparation", async () => {
+		const selector = { language: "typescript" }
+		const project = fakeProject("prepared", [selector])
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await runtime.replaceProject("/prepared.inlang")
+
+		expect(host.prepareProject).toHaveBeenCalledBefore(
+			project.plugins.get as ReturnType<typeof vi.fn>
+		)
+		expect(host.registerCodeActionsProvider).toHaveBeenCalledWith(
+			[{ language: "javascript", pattern: "!project.inlang/settings.json" }, selector],
+			expect.anything(),
+			{ providedCodeActionKinds: ["quickfix"] }
+		)
+	})
+
+	it("owns immediate resources only for their candidate session", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		const firstResource = disposable()
+		const secondResource = disposable()
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+		host.registerCodeActionsProvider
+			.mockReturnValueOnce(firstResource)
+			.mockReturnValueOnce(secondResource)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await runtime.replaceProject("/first.inlang")
+		const firstSession = host.messagePreview.mock.calls[0]?.[0].session
+		await runtime.replaceProject("/second.inlang")
+		const secondSession = host.messagePreview.mock.calls[1]?.[0].session
+
+		expect(firstSession).not.toBe(secondSession)
+		expect(firstResource.dispose).toHaveBeenCalledTimes(1)
+		expect(secondResource.dispose).not.toHaveBeenCalled()
+		expect(firstSession.own(disposable())).toBe(false)
+		expect(secondSession.own(disposable())).toBe(true)
+	})
+
+	it("disposes a candidate with failed required activation and preserves the previous session", async () => {
+		const first = fakeProject("first")
+		const failed = fakeProject("failed")
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(failed)
+		host.registerCodeActionsProvider
+			.mockImplementationOnce(() => disposable())
+			.mockImplementationOnce(() => {
+				throw new Error("registration failed")
+			})
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		const previousLease = runtime.activeProject()
+
+		await expect(runtime.replaceProject("/failed.inlang")).resolves.toMatchObject({
+			status: "failed",
+		})
+
+		expect(previousLease?.isCurrent()).toBe(true)
+		expect(first.close).not.toHaveBeenCalled()
+		expect(failed.close).toHaveBeenCalledTimes(1)
+	})
+
+	it("deactivates immediate resources before closing the previous project", async () => {
+		const order: string[] = []
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		;(first.close as ReturnType<typeof vi.fn>).mockImplementation(async () => {
+			order.push("project")
+		})
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+		host.registerCodeActionsProvider.mockReturnValueOnce(
+			disposable(() => order.push("code-action"))
+		)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+
+		await runtime.replaceProject("/second.inlang")
+
+		expect(order.indexOf("code-action")).toBeLessThan(order.indexOf("project"))
+	})
+
+	it("disposes session resources in reverse ownership order", async () => {
+		const order: string[] = []
+		const project = fakeProject("active")
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		host.registerCodeActionsProvider.mockReturnValue(disposable(() => order.push("code-action")))
+		host.messagePreview.mockImplementation(({ subscriptions }) => {
+			subscriptions.push(disposable(() => order.push("preview")))
+		})
+		host.linterDiagnostics.mockImplementation(async ({ subscriptions }) => {
+			subscriptions.push(disposable(() => order.push("diagnostics")))
+		})
+		const messageView = {
+			bindProject: vi.fn(() => disposable(() => order.push("message-view"))),
+		}
+		const runtime = createProjectSessionEnvironment({ fileSystem, messageView })
+		await runtime.replaceProject("/active.inlang")
+
+		await runtime.dispose()
+
+		expect(order).toEqual(["message-view", "diagnostics", "preview", "code-action"])
+	})
+
+	it("allows an absent message view and binds a present view once per committed session", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+		const withoutView = createProjectSessionEnvironment({ fileSystem })
+		await expect(withoutView.replaceProject("/first.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+		await withoutView.dispose()
+
+		const messageView = { bindProject: vi.fn(() => disposable()) }
+		const withView = createProjectSessionEnvironment({ fileSystem, messageView })
+		await withView.replaceProject("/second.inlang")
+
+		expect(messageView.bindProject).toHaveBeenCalledTimes(1)
+	})
+
+	it("reports diagnostics activation rejection", async () => {
+		const error = new Error("diagnostics failed")
+		const project = fakeProject("active")
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		host.linterDiagnostics.mockRejectedValue(error)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await expect(runtime.replaceProject("/active.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+		await vi.waitFor(() => expect(host.handleError).toHaveBeenCalledWith(error))
 	})
 })

--- a/src/utilities/project/projectSessionEnvironment.test.ts
+++ b/src/utilities/project/projectSessionEnvironment.test.ts
@@ -1,24 +1,65 @@
 import { beforeEach, describe, expect, it, vi } from "vitest"
 import type { InlangProject } from "@inlang/sdk"
+import crypto from "node:crypto"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
 
-const host = vi.hoisted(() => ({
-	loadProjectFromDirectory: vi.fn(),
-	prepareProject: vi.fn(),
-	setActiveProject: vi.fn(),
-	registerCodeActionsProvider: vi.fn(),
-	messagePreview: vi.fn(),
-	linterDiagnostics: vi.fn(),
-	handleError: vi.fn(),
-	createResourceLoadTracker: vi.fn(() => ({
-		fs: { tracked: true },
-		snapshot: vi.fn(),
-	})),
-}))
+const host = vi.hoisted(() => {
+	const watchers: Array<{
+		callbacks: Record<string, () => void>
+		dispose: ReturnType<typeof vi.fn>
+	}> = []
+	const fileContents = new Map<string, Uint8Array | Error>()
+	return {
+		loadProjectFromDirectory: vi.fn(),
+		prepareProject: vi.fn(),
+		setActiveProject: vi.fn(),
+		registerCodeActionsProvider: vi.fn(),
+		messagePreview: vi.fn(),
+		linterDiagnostics: vi.fn(),
+		handleError: vi.fn(),
+		projectChange: vi.fn(),
+		watchers,
+		fileContents,
+		readFile: vi.fn(async (uri: { fsPath: string }) => {
+			const content: Uint8Array | Error | undefined = fileContents.get(uri.fsPath)
+			if (content instanceof Error) throw content
+			if (!content) throw Object.assign(new Error("missing"), { code: "ENOENT" })
+			return content
+		}),
+		createFileSystemWatcher: vi.fn(() => {
+			const callbacks: Record<string, () => void> = {}
+			const watcher = {
+				callbacks,
+				onDidCreate: vi.fn((callback: () => void) => {
+					callbacks.create = callback
+				}),
+				onDidChange: vi.fn((callback: () => void) => {
+					callbacks.change = callback
+				}),
+				onDidDelete: vi.fn((callback: () => void) => {
+					callbacks.delete = callback
+				}),
+				dispose: vi.fn(),
+			}
+			watchers.push(watcher)
+			return watcher
+		}),
+		createResourceLoadTracker: vi.fn(() => ({
+			fs: { tracked: true },
+			snapshot: new Map(),
+		})),
+	}
+})
 
 vi.mock("vscode", () => ({
+	RelativePattern: class {},
+	Uri: { file: (fsPath: string) => ({ fsPath }) },
 	languages: {
 		registerCodeActionsProvider: host.registerCodeActionsProvider,
+	},
+	workspace: {
+		createFileSystemWatcher: host.createFileSystemWatcher,
+		fs: { readFile: host.readFile },
 	},
 }))
 
@@ -31,7 +72,8 @@ vi.mock("../state.js", () => ({
 	setActiveProject: host.setActiveProject,
 }))
 
-vi.mock("../fs/pluginResourceWatcher.js", () => ({
+vi.mock("../fs/pluginResourceWatcher.js", async (importOriginal) => ({
+	...(await importOriginal<typeof import("../fs/pluginResourceWatcher.js")>()),
 	createResourceLoadTracker: host.createResourceLoadTracker,
 }))
 
@@ -52,6 +94,7 @@ vi.mock("../../actions/extractMessage.js", () => ({
 vi.mock("../../configuration.js", () => ({
 	CONFIGURATION: {
 		FILES: { PROJECT: "project.inlang/settings.json" },
+		EVENTS: { ON_DID_PROJECT_CHANGE: { fire: host.projectChange } },
 	},
 }))
 
@@ -61,10 +104,16 @@ vi.mock("../utils.js", () => ({
 
 import { createProjectSessionEnvironment } from "./projectSessionEnvironment.js"
 
-function fakeProject(name: string, documentSelectors: Array<{ language: string }> = []) {
+function fakeProject(
+	name: string,
+	documentSelectors: Array<{ language: string }> = [],
+	resourcePaths: string[] = []
+) {
 	return {
 		name,
 		close: vi.fn(async () => undefined),
+		settings: { get: vi.fn(async () => ({ locales: ["en"] })) },
+		errors: { get: vi.fn(async () => []) },
 		plugins: {
 			get: vi.fn(async () => [
 				{
@@ -72,6 +121,17 @@ function fakeProject(name: string, documentSelectors: Array<{ language: string }
 						"app.inlang.ideExtension": { documentSelectors },
 					},
 				},
+				...(resourcePaths.length
+					? [
+							{
+								key: `plugin.${name}`,
+								importFiles: vi.fn(),
+								toBeImportedFiles: vi.fn(async () =>
+									resourcePaths.map((path) => ({ path, locale: "en" }))
+								),
+							},
+						]
+					: []),
 			]),
 		},
 	} as unknown as InlangProject
@@ -79,10 +139,12 @@ function fakeProject(name: string, documentSelectors: Array<{ language: string }
 
 function deferred<T>() {
 	let resolve!: (value: T) => void
-	const promise = new Promise<T>((resolvePromise) => {
+	let reject!: (error: unknown) => void
+	const promise = new Promise<T>((resolvePromise, rejectPromise) => {
 		resolve = resolvePromise
+		reject = rejectPromise
 	})
-	return { promise, resolve }
+	return { promise, resolve, reject }
 }
 
 const fileSystem = {} as FileSystem
@@ -91,15 +153,29 @@ function disposable(onDispose: () => unknown = vi.fn()) {
 	return { deactivate: onDispose, dispose: onDispose }
 }
 
+const bytes = (value: string) => new TextEncoder().encode(value)
+const fingerprint = (value: string) => crypto.createHash("sha256").update(value).digest("hex")
+const trackerWithSnapshot = (entries: Array<[string, string]>) => ({
+	fs: { tracked: true },
+	snapshot: new Map(entries),
+})
+
 beforeEach(() => {
 	vi.clearAllMocks()
+	host.loadProjectFromDirectory.mockReset()
+	host.createResourceLoadTracker.mockReset()
+	host.registerCodeActionsProvider.mockReset()
+	host.messagePreview.mockReset()
+	host.linterDiagnostics.mockReset()
 	host.createResourceLoadTracker.mockReturnValue({
 		fs: { tracked: true },
-		snapshot: vi.fn(),
+		snapshot: new Map(),
 	})
 	host.registerCodeActionsProvider.mockImplementation(() => disposable())
 	host.messagePreview.mockImplementation(() => undefined)
 	host.linterDiagnostics.mockResolvedValue(undefined)
+	host.watchers.length = 0
+	host.fileContents.clear()
 })
 
 describe("project session environment", () => {
@@ -274,12 +350,16 @@ describe("project session environment", () => {
 		const project = fakeProject("active")
 		host.loadProjectFromDirectory.mockResolvedValue(project)
 		host.registerCodeActionsProvider.mockReturnValue(disposable(() => order.push("code-action")))
-		host.messagePreview.mockImplementation(({ subscriptions }) => {
-			subscriptions.push(disposable(() => order.push("preview")))
-		})
-		host.linterDiagnostics.mockImplementation(async ({ subscriptions }) => {
-			subscriptions.push(disposable(() => order.push("diagnostics")))
-		})
+		host.messagePreview.mockImplementation(
+			({ subscriptions }: { subscriptions: Array<ReturnType<typeof disposable>> }) => {
+				subscriptions.push(disposable(() => order.push("preview")))
+			}
+		)
+		host.linterDiagnostics.mockImplementation(
+			async ({ subscriptions }: { subscriptions: Array<ReturnType<typeof disposable>> }) => {
+				subscriptions.push(disposable(() => order.push("diagnostics")))
+			}
+		)
 		const messageView = {
 			bindProject: vi.fn(() => disposable(() => order.push("message-view"))),
 		}
@@ -319,5 +399,188 @@ describe("project session environment", () => {
 			status: "committed",
 		})
 		await vi.waitFor(() => expect(host.handleError).toHaveBeenCalledWith(error))
+	})
+
+	it("pairs each watcher with the snapshot from its own overlapping project load", async () => {
+		vi.useFakeTimers()
+		const resourcePath = "/resources/messages.json"
+		const first = fakeProject("first", [], [resourcePath])
+		const superseded = fakeProject("superseded", [], [resourcePath])
+		const latest = fakeProject("latest", [], [resourcePath])
+		const slow = deferred<InlangProject>()
+		host.fileContents.set(resourcePath, bytes("first"))
+		host.createResourceLoadTracker
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("first")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("superseded")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("latest")]]))
+		host.loadProjectFromDirectory
+			.mockResolvedValueOnce(first)
+			.mockReturnValueOnce(slow.promise)
+			.mockResolvedValueOnce(latest)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+
+		host.fileContents.set(resourcePath, bytes("latest"))
+		const olderReplacement = runtime.replaceProject("/superseded.inlang")
+		const latestReplacement = runtime.replaceProject("/latest.inlang")
+		slow.resolve(superseded)
+
+		await expect(olderReplacement).resolves.toEqual({ status: "superseded" })
+		await expect(latestReplacement).resolves.toEqual({ status: "committed" })
+		await vi.advanceTimersByTimeAsync(200)
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(3)
+		expect(runtime.activeProject()?.project).toBe(latest)
+	})
+
+	it("closes the previous project before the next watcher becomes authoritative", async () => {
+		const first = fakeProject("first", [], ["/resources/first.json"])
+		const second = fakeProject("second", [], ["/resources/second.json"])
+		host.fileContents.set("/resources/first.json", bytes("first"))
+		host.fileContents.set("/resources/second.json", bytes("second"))
+		host.createResourceLoadTracker
+			.mockReturnValueOnce(trackerWithSnapshot([["/resources/first.json", fingerprint("first")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([["/resources/second.json", fingerprint("second")]]))
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+
+		await runtime.replaceProject("/second.inlang")
+
+		expect((first.close as ReturnType<typeof vi.fn>).mock.invocationCallOrder[0]).toBeLessThan(
+			host.createFileSystemWatcher.mock.invocationCallOrder[1]!
+		)
+		expect(host.watchers[0]?.dispose).toHaveBeenCalledTimes(1)
+		await runtime.dispose()
+	})
+
+	it("reconciles a resource change across the load-to-watch handoff", async () => {
+		vi.useFakeTimers()
+		const resourcePath = "/resources/messages.json"
+		const initial = fakeProject("initial", [], [resourcePath])
+		const reconciled = fakeProject("reconciled")
+		host.fileContents.set(resourcePath, bytes("after-load"))
+		host.createResourceLoadTracker.mockReturnValueOnce(
+			trackerWithSnapshot([[resourcePath, fingerprint("during-load")]])
+		)
+		host.loadProjectFromDirectory.mockResolvedValueOnce(initial).mockResolvedValueOnce(reconciled)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await runtime.replaceProject("/project.inlang")
+		await vi.advanceTimersByTimeAsync(200)
+		for (let index = 0; index < 10; index += 1) await Promise.resolve()
+
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(2)
+		expect(runtime.activeProject()?.project).toBe(reconciled)
+	})
+
+	it("keeps an explicit selection over reconciliation from the prior project", async () => {
+		vi.useFakeTimers()
+		const resourcePath = "/resources/messages.json"
+		const first = fakeProject("first", [], [resourcePath])
+		const second = fakeProject("second")
+		const secondLoad = deferred<InlangProject>()
+		host.fileContents.set(resourcePath, bytes("first"))
+		host.createResourceLoadTracker.mockReturnValueOnce(
+			trackerWithSnapshot([[resourcePath, fingerprint("first")]])
+		)
+		host.loadProjectFromDirectory
+			.mockResolvedValueOnce(first)
+			.mockReturnValueOnce(secondLoad.promise)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		host.fileContents.set(resourcePath, bytes("changed"))
+		host.watchers[0]?.callbacks.change?.()
+		await vi.advanceTimersByTimeAsync(1)
+
+		const explicitReplacement = runtime.replaceProject("/second.inlang")
+		await vi.advanceTimersByTimeAsync(200)
+		secondLoad.resolve(second)
+
+		await expect(explicitReplacement).resolves.toEqual({ status: "committed" })
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(2)
+		expect(runtime.activeProject()?.project).toBe(second)
+	})
+
+	it("replays deferred reconciliation when a newer explicit selection fails", async () => {
+		vi.useFakeTimers()
+		const resourcePath = "/resources/messages.json"
+		const first = fakeProject("first", [], [resourcePath])
+		const reconciled = fakeProject("reconciled")
+		const secondLoad = deferred<InlangProject>()
+		host.fileContents.set(resourcePath, bytes("first"))
+		host.createResourceLoadTracker.mockReturnValueOnce(
+			trackerWithSnapshot([[resourcePath, fingerprint("first")]])
+		)
+		host.loadProjectFromDirectory
+			.mockResolvedValueOnce(first)
+			.mockReturnValueOnce(secondLoad.promise)
+			.mockResolvedValueOnce(reconciled)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		host.fileContents.set(resourcePath, bytes("changed"))
+		host.watchers[0]?.callbacks.change?.()
+		await vi.advanceTimersByTimeAsync(1)
+
+		const failedReplacement = runtime.replaceProject("/second.inlang")
+		await vi.advanceTimersByTimeAsync(200)
+		secondLoad.reject(new Error("selection failed"))
+
+		await expect(failedReplacement).resolves.toMatchObject({ status: "failed" })
+		await vi.waitFor(() => expect(runtime.activeProject()?.project).toBe(reconciled))
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(3)
+	})
+
+	it("reports watcher setup failure without changing committed replacement semantics", async () => {
+		const watcherError = new Error("watcher setup failed")
+		const project = fakeProject("active")
+		;(project.settings.get as ReturnType<typeof vi.fn>).mockRejectedValue(watcherError)
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await expect(runtime.replaceProject("/active.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+
+		expect(host.handleError).toHaveBeenCalledWith(watcherError)
+		expect(project.errors.get).not.toHaveBeenCalled()
+		expect(host.projectChange).toHaveBeenCalledTimes(1)
+	})
+
+	it("notifies exactly once for committed replacements only", async () => {
+		const first = fakeProject("first")
+		const superseded = fakeProject("superseded")
+		const latest = fakeProject("latest")
+		const slow = deferred<InlangProject>()
+		host.loadProjectFromDirectory
+			.mockResolvedValueOnce(first)
+			.mockRejectedValueOnce(new Error("load failed"))
+			.mockReturnValueOnce(slow.promise)
+			.mockResolvedValueOnce(latest)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await runtime.replaceProject("/first.inlang")
+		await runtime.replaceProject("/failed.inlang")
+		const olderReplacement = runtime.replaceProject("/superseded.inlang")
+		const latestReplacement = runtime.replaceProject("/latest.inlang")
+		slow.resolve(superseded)
+		await olderReplacement
+		await latestReplacement
+
+		expect(host.projectChange).toHaveBeenCalledTimes(2)
+	})
+
+	it("disposes the active watcher once across repeated bounded shutdown", async () => {
+		const resourcePath = "/resources/messages.json"
+		const project = fakeProject("active", [], [resourcePath])
+		host.fileContents.set(resourcePath, bytes("active"))
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/active.inlang")
+
+		await Promise.all([runtime.dispose(), runtime.dispose()])
+
+		expect(host.watchers).toHaveLength(1)
+		expect(host.watchers[0]?.dispose).toHaveBeenCalledTimes(1)
+		expect(project.close).toHaveBeenCalledTimes(1)
 	})
 })

--- a/src/utilities/project/projectSessionEnvironment.test.ts
+++ b/src/utilities/project/projectSessionEnvironment.test.ts
@@ -1,0 +1,139 @@
+import { beforeEach, describe, expect, it, vi } from "vitest"
+import type { InlangProject } from "@inlang/sdk"
+import type { FileSystem } from "../fs/createFileSystemMapper.js"
+
+const host = vi.hoisted(() => ({
+	loadProjectFromDirectory: vi.fn(),
+	prepareProject: vi.fn(),
+	setActiveProject: vi.fn(),
+	createResourceLoadTracker: vi.fn(() => ({
+		fs: { tracked: true },
+		snapshot: vi.fn(),
+	})),
+}))
+
+vi.mock("@inlang/sdk", () => ({
+	loadProjectFromDirectory: host.loadProjectFromDirectory,
+}))
+
+vi.mock("../state.js", () => ({
+	prepareProject: host.prepareProject,
+	setActiveProject: host.setActiveProject,
+}))
+
+vi.mock("../fs/pluginResourceWatcher.js", () => ({
+	createResourceLoadTracker: host.createResourceLoadTracker,
+}))
+
+import { createProjectSessionEnvironment } from "./projectSessionEnvironment.js"
+
+function fakeProject(name: string) {
+	return {
+		name,
+		close: vi.fn(async () => undefined),
+	} as unknown as InlangProject
+}
+
+function deferred<T>() {
+	let resolve!: (value: T) => void
+	const promise = new Promise<T>((resolvePromise) => {
+		resolve = resolvePromise
+	})
+	return { promise, resolve }
+}
+
+const fileSystem = {} as FileSystem
+
+beforeEach(() => {
+	vi.clearAllMocks()
+	host.createResourceLoadTracker.mockReturnValue({
+		fs: { tracked: true },
+		snapshot: vi.fn(),
+	})
+})
+
+describe("project session environment", () => {
+	it("loads and publishes the first project", async () => {
+		const project = fakeProject("first")
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+
+		await expect(runtime.replaceProject("/first.inlang")).resolves.toEqual({
+			status: "committed",
+		})
+
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledWith({
+			path: "/first.inlang",
+			fs: { tracked: true },
+		})
+		expect(host.prepareProject).toHaveBeenCalledWith(project)
+		expect(host.setActiveProject).toHaveBeenLastCalledWith({
+			project,
+			path: "/first.inlang",
+		})
+		expect(runtime.activeProject()?.project).toBe(project)
+	})
+
+	it("keeps the prior active lease current when loading fails", async () => {
+		const first = fakeProject("first")
+		host.loadProjectFromDirectory
+			.mockResolvedValueOnce(first)
+			.mockRejectedValueOnce(new Error("load failed"))
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		const lease = runtime.activeProject()
+
+		await expect(runtime.replaceProject("/failed.inlang")).resolves.toMatchObject({
+			status: "failed",
+		})
+
+		expect(lease?.isCurrent()).toBe(true)
+		expect(runtime.activeProject()?.project).toBe(first)
+		expect(first.close).not.toHaveBeenCalled()
+	})
+
+	it("lets a newer replacement supersede an older unresolved load", async () => {
+		const slow = deferred<InlangProject>()
+		const older = fakeProject("older")
+		const newer = fakeProject("newer")
+		host.loadProjectFromDirectory.mockReturnValueOnce(slow.promise).mockResolvedValueOnce(newer)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		const olderReplacement = runtime.replaceProject("/older.inlang")
+		const newerReplacement = runtime.replaceProject("/newer.inlang")
+		slow.resolve(older)
+
+		await expect(olderReplacement).resolves.toEqual({ status: "superseded" })
+		await expect(newerReplacement).resolves.toEqual({ status: "committed" })
+		expect(older.close).toHaveBeenCalledTimes(1)
+		expect(runtime.activeProject()?.project).toBe(newer)
+	})
+
+	it("invalidates the prior lease and closes its project on replacement", async () => {
+		const first = fakeProject("first")
+		const second = fakeProject("second")
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(second)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		const lease = runtime.activeProject()
+
+		await runtime.replaceProject("/second.inlang")
+
+		expect(lease?.isCurrent()).toBe(false)
+		expect(first.close).toHaveBeenCalledTimes(1)
+		expect(runtime.activeProject()?.project).toBe(second)
+	})
+
+	it("unpublishes the project and disposes idempotently", async () => {
+		const project = fakeProject("active")
+		host.loadProjectFromDirectory.mockResolvedValue(project)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/active.inlang")
+
+		await runtime.dispose()
+		await runtime.dispose()
+
+		expect(host.setActiveProject).toHaveBeenLastCalledWith(undefined)
+		expect(project.close).toHaveBeenCalledTimes(1)
+		expect(runtime.activeProject()).toBeUndefined()
+	})
+})

--- a/src/utilities/project/projectSessionEnvironment.test.ts
+++ b/src/utilities/project/projectSessionEnvironment.test.ts
@@ -222,6 +222,34 @@ describe("project session environment", () => {
 		expect(first.close).not.toHaveBeenCalled()
 	})
 
+	it("rolls active publication back when publishing a candidate fails", async () => {
+		const first = fakeProject("first")
+		const candidate = fakeProject("candidate")
+		const publicationError = new Error("publication failed")
+		host.loadProjectFromDirectory.mockResolvedValueOnce(first).mockResolvedValueOnce(candidate)
+		const runtime = createProjectSessionEnvironment({ fileSystem })
+		await runtime.replaceProject("/first.inlang")
+		const previousLease = runtime.activeProject()
+		host.setActiveProject.mockImplementationOnce(() => {
+			throw publicationError
+		})
+
+		await expect(runtime.replaceProject("/candidate.inlang")).resolves.toEqual({
+			status: "failed",
+			error: publicationError,
+		})
+
+		expect(previousLease?.isCurrent()).toBe(true)
+		expect(runtime.activeProject()?.project).toBe(first)
+		expect(host.setActiveProject).toHaveBeenLastCalledWith({
+			project: first,
+			path: "/first.inlang",
+		})
+		expect(first.close).not.toHaveBeenCalled()
+		expect(candidate.close).toHaveBeenCalledTimes(1)
+		expect(host.projectChange).toHaveBeenCalledTimes(1)
+	})
+
 	it("lets a newer replacement supersede an older unresolved load", async () => {
 		const slow = deferred<InlangProject>()
 		const older = fakeProject("older")
@@ -405,35 +433,45 @@ describe("project session environment", () => {
 		await vi.waitFor(() => expect(host.handleError).toHaveBeenCalledWith(error))
 	})
 
-	it("pairs each watcher with the snapshot from its own overlapping project load", async () => {
+	it("reconciles the committed watcher from its own overlapping project snapshot", async () => {
 		vi.useFakeTimers()
 		const resourcePath = "/resources/messages.json"
 		const first = fakeProject("first", [], [resourcePath])
 		const superseded = fakeProject("superseded", [], [resourcePath])
 		const latest = fakeProject("latest", [], [resourcePath])
+		const reconciled = fakeProject("reconciled")
 		const slow = deferred<InlangProject>()
-		host.fileContents.set(resourcePath, bytes("first"))
+		const latestPreparation = deferred<Awaited<ReturnType<InlangProject["plugins"]["get"]>>>()
+		const latestPlugins = await latest.plugins.get()
+		;(latest.plugins.get as ReturnType<typeof vi.fn>)
+			.mockReturnValueOnce(latestPreparation.promise)
+			.mockResolvedValue(latestPlugins)
+		host.fileContents.set(resourcePath, bytes("current"))
 		host.createResourceLoadTracker
-			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("first")]]))
-			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("superseded")]]))
-			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("latest")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("current")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("current")]]))
+			.mockReturnValueOnce(trackerWithSnapshot([[resourcePath, fingerprint("during-latest-load")]]))
 		host.loadProjectFromDirectory
 			.mockResolvedValueOnce(first)
 			.mockReturnValueOnce(slow.promise)
 			.mockResolvedValueOnce(latest)
+			.mockResolvedValueOnce(reconciled)
 		const runtime = createProjectSessionEnvironment({ fileSystem })
 		await runtime.replaceProject("/first.inlang")
 
-		host.fileContents.set(resourcePath, bytes("latest"))
 		const olderReplacement = runtime.replaceProject("/superseded.inlang")
 		const latestReplacement = runtime.replaceProject("/latest.inlang")
+		for (let index = 0; index < 10; index += 1) await Promise.resolve()
 		slow.resolve(superseded)
-
+		for (let index = 0; index < 10; index += 1) await Promise.resolve()
+		latestPreparation.resolve(latestPlugins)
 		await expect(olderReplacement).resolves.toEqual({ status: "superseded" })
 		await expect(latestReplacement).resolves.toEqual({ status: "committed" })
 		await vi.advanceTimersByTimeAsync(200)
-		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(3)
-		expect(runtime.activeProject()?.project).toBe(latest)
+		for (let index = 0; index < 10; index += 1) await Promise.resolve()
+
+		expect(host.loadProjectFromDirectory).toHaveBeenCalledTimes(4)
+		expect(runtime.activeProject()?.project).toBe(reconciled)
 	})
 
 	it("closes the previous project before the next watcher becomes authoritative", async () => {
@@ -573,18 +611,24 @@ describe("project session environment", () => {
 		expect(host.projectChange).toHaveBeenCalledTimes(2)
 	})
 
-	it("disposes the active watcher once across repeated bounded shutdown", async () => {
+	it("bounds repeated shutdown and disposes the active watcher once", async () => {
+		vi.useFakeTimers()
 		const resourcePath = "/resources/messages.json"
 		const project = fakeProject("active", [], [resourcePath])
 		host.fileContents.set(resourcePath, bytes("active"))
 		host.loadProjectFromDirectory.mockResolvedValue(project)
 		const runtime = createProjectSessionEnvironment({ fileSystem })
 		await runtime.replaceProject("/active.inlang")
+		void runtime.activeProject()?.runTask(() => new Promise<void>(() => undefined))
 
-		await Promise.all([runtime.dispose(), runtime.dispose()])
+		const firstDisposal = runtime.dispose()
+		const secondDisposal = runtime.dispose()
+		expect(firstDisposal).toBe(secondDisposal)
+		await vi.advanceTimersByTimeAsync(1_001)
+		await Promise.all([firstDisposal, secondDisposal])
 
 		expect(host.watchers).toHaveLength(1)
 		expect(host.watchers[0]?.dispose).toHaveBeenCalledTimes(1)
-		expect(project.close).toHaveBeenCalledTimes(1)
+		expect(project.close).not.toHaveBeenCalled()
 	})
 })

--- a/src/utilities/project/projectSessionEnvironment.ts
+++ b/src/utilities/project/projectSessionEnvironment.ts
@@ -1,0 +1,35 @@
+import { loadProjectFromDirectory, type InlangProject } from "@inlang/sdk"
+import * as nodeFs from "node:fs"
+import type { MessageViewController } from "../messages/messages.js"
+import type { FileSystem } from "../fs/createFileSystemMapper.js"
+import { createResourceLoadTracker } from "../fs/pluginResourceWatcher.js"
+import { prepareProject, setActiveProject } from "../state.js"
+import { createProjectRuntime, type ProjectRuntime } from "./projectRuntime.js"
+
+export type ProjectSessionEnvironmentArgs = {
+	fileSystem: FileSystem
+	messageView?: Pick<MessageViewController, "bindProject">
+}
+
+export function createProjectSessionEnvironment(
+	args: ProjectSessionEnvironmentArgs
+): ProjectRuntime<InlangProject> {
+	void args
+	const resourceLoadSnapshots = new WeakMap<
+		InlangProject,
+		ReturnType<typeof createResourceLoadTracker>["snapshot"]
+	>()
+
+	return createProjectRuntime({
+		loadProject: async (projectPath) => {
+			const loadTracker = createResourceLoadTracker(nodeFs)
+			const project = await loadProjectFromDirectory({ path: projectPath, fs: loadTracker.fs })
+			resourceLoadSnapshots.set(project, loadTracker.snapshot)
+			prepareProject(project)
+			return project
+		},
+		prepareSession: async () => ({ activate: () => undefined }),
+		publishActiveSession: (session) =>
+			setActiveProject(session ? { project: session.project, path: session.path } : undefined),
+	})
+}

--- a/src/utilities/project/projectSessionEnvironment.ts
+++ b/src/utilities/project/projectSessionEnvironment.ts
@@ -18,7 +18,6 @@ import {
 	createProjectSessionLifecycle,
 	deactivateBeforeClose,
 	type Disposable,
-	type PreparedProjectSession,
 	type ProjectSession,
 } from "./projectSession.js"
 
@@ -104,7 +103,10 @@ function createEnvironmentRuntime<Project extends { close(): Promise<void> }>(ar
 	prepareSession(
 		session: ProjectSession<Project>,
 		resources: Disposable[]
-	): Promise<PreparedProjectSession>
+	): Promise<{
+		activate(): void
+		afterPreviousDisposed?(): Promise<void> | void
+	}>
 	publishActiveSession(session: ProjectSession<Project> | undefined): void
 	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
 	onError?(

--- a/src/utilities/project/projectSessionEnvironment.ts
+++ b/src/utilities/project/projectSessionEnvironment.ts
@@ -13,8 +13,14 @@ import {
 } from "../fs/pluginResourceWatcher.js"
 import { prepareProject, setActiveProject } from "../state.js"
 import { handleError } from "../utils.js"
-import { createProjectRuntime, type ProjectRuntime } from "./projectRuntime.js"
-import { deactivateBeforeClose } from "./projectSession.js"
+import type { ProjectRuntime } from "./projectRuntime.js"
+import {
+	createProjectSessionLifecycle,
+	deactivateBeforeClose,
+	type Disposable,
+	type PreparedProjectSession,
+	type ProjectSession,
+} from "./projectSession.js"
 
 export type ProjectSessionEnvironmentArgs = {
 	fileSystem: FileSystem
@@ -29,7 +35,7 @@ export function createProjectSessionEnvironment(
 		ReturnType<typeof createResourceLoadTracker>["snapshot"]
 	>()
 
-	return createProjectRuntime({
+	return createEnvironmentRuntime({
 		loadProject: async (projectPath) => {
 			const loadTracker = createResourceLoadTracker(nodeFs)
 			const project = await loadProjectFromDirectory({ path: projectPath, fs: loadTracker.fs })
@@ -90,5 +96,52 @@ async function handleInlangErrors(project: InlangProject) {
 	const inlangErrors = (await project.errors.get()) || []
 	if (inlangErrors.length > 0) {
 		console.error("Extension errors (Sherlock):", inlangErrors)
+	}
+}
+
+function createEnvironmentRuntime<Project extends { close(): Promise<void> }>(args: {
+	loadProject(path: string): Promise<Project>
+	prepareSession(
+		session: ProjectSession<Project>,
+		resources: Disposable[]
+	): Promise<PreparedProjectSession>
+	publishActiveSession(session: ProjectSession<Project> | undefined): void
+	onDidReplaceSession?(session: ProjectSession<Project>): Promise<void> | void
+	onError?(
+		error: unknown,
+		phase: "cleanup" | "activation" | "notification" | "reconciliation"
+	): void
+}): ProjectRuntime<Project> {
+	let activeSession: ProjectSession<Project> | undefined
+	let lastRequestedProjectPath: string | undefined
+	const lifecycle = createProjectSessionLifecycle({
+		loadProject: args.loadProject,
+		prepareSession: args.prepareSession,
+		setActiveSession: (session) => {
+			args.publishActiveSession(session)
+			activeSession = session
+		},
+		onDidReplaceSession: args.onDidReplaceSession,
+		onError: args.onError,
+	})
+
+	return {
+		replaceProject(path) {
+			lastRequestedProjectPath = path
+			return lifecycle.replaceProject(path)
+		},
+		activeProject() {
+			const session = activeSession
+			if (!session) return undefined
+			return {
+				path: session.path,
+				project: session.project,
+				isCurrent: () => activeSession === session,
+				own: (resource) => session.own(resource),
+				runTask: (task) => session.runTask(task),
+			}
+		},
+		lastRequestedProjectPath: () => lastRequestedProjectPath,
+		dispose: lifecycle.dispose,
 	}
 }

--- a/src/utilities/project/projectSessionEnvironment.ts
+++ b/src/utilities/project/projectSessionEnvironment.ts
@@ -7,7 +7,10 @@ import { messagePreview } from "../../decorations/messagePreview.js"
 import { linterDiagnostics } from "../../diagnostics/linterDiagnostics.js"
 import type { MessageViewController } from "../messages/messages.js"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
-import { createResourceLoadTracker } from "../fs/pluginResourceWatcher.js"
+import {
+	createResourceLoadTracker,
+	setupPluginResourceWatcher,
+} from "../fs/pluginResourceWatcher.js"
 import { prepareProject, setActiveProject } from "../state.js"
 import { handleError } from "../utils.js"
 import { createProjectRuntime, type ProjectRuntime } from "./projectRuntime.js"
@@ -62,9 +65,30 @@ export function createProjectSessionEnvironment(
 						resources.push(deactivateBeforeClose(args.messageView.bindProject(session)))
 					}
 				},
+				afterPreviousDisposed: async () => {
+					await setupPluginResourceWatcher({
+						session,
+						loadSnapshot: resourceLoadSnapshots.get(session.project),
+						onError: handleError,
+					})
+					await session
+						.runTask(async () => {
+							await handleInlangErrors(session.project)
+						})
+						.catch(handleError)
+				},
 			}
 		},
 		publishActiveSession: (session) =>
 			setActiveProject(session ? { project: session.project, path: session.path } : undefined),
+		onDidReplaceSession: () => CONFIGURATION.EVENTS.ON_DID_PROJECT_CHANGE.fire(undefined),
+		onError: (error) => handleError(error),
 	})
+}
+
+async function handleInlangErrors(project: InlangProject) {
+	const inlangErrors = (await project.errors.get()) || []
+	if (inlangErrors.length > 0) {
+		console.error("Extension errors (Sherlock):", inlangErrors)
+	}
 }

--- a/src/utilities/project/projectSessionEnvironment.ts
+++ b/src/utilities/project/projectSessionEnvironment.ts
@@ -1,10 +1,17 @@
-import { loadProjectFromDirectory, type InlangProject } from "@inlang/sdk"
+import { loadProjectFromDirectory, type IdeExtensionConfig, type InlangProject } from "@inlang/sdk"
 import * as nodeFs from "node:fs"
+import * as vscode from "vscode"
+import { ExtractMessage } from "../../actions/extractMessage.js"
+import { CONFIGURATION } from "../../configuration.js"
+import { messagePreview } from "../../decorations/messagePreview.js"
+import { linterDiagnostics } from "../../diagnostics/linterDiagnostics.js"
 import type { MessageViewController } from "../messages/messages.js"
 import type { FileSystem } from "../fs/createFileSystemMapper.js"
 import { createResourceLoadTracker } from "../fs/pluginResourceWatcher.js"
 import { prepareProject, setActiveProject } from "../state.js"
+import { handleError } from "../utils.js"
 import { createProjectRuntime, type ProjectRuntime } from "./projectRuntime.js"
+import { deactivateBeforeClose } from "./projectSession.js"
 
 export type ProjectSessionEnvironmentArgs = {
 	fileSystem: FileSystem
@@ -14,7 +21,6 @@ export type ProjectSessionEnvironmentArgs = {
 export function createProjectSessionEnvironment(
 	args: ProjectSessionEnvironmentArgs
 ): ProjectRuntime<InlangProject> {
-	void args
 	const resourceLoadSnapshots = new WeakMap<
 		InlangProject,
 		ReturnType<typeof createResourceLoadTracker>["snapshot"]
@@ -28,7 +34,36 @@ export function createProjectSessionEnvironment(
 			prepareProject(project)
 			return project
 		},
-		prepareSession: async () => ({ activate: () => undefined }),
+		prepareSession: async (session, resources) => {
+			const ideExtension = (await session.project.plugins.get()).find(
+				(plugin) => plugin?.meta?.["app.inlang.ideExtension"]
+			)?.meta?.["app.inlang.ideExtension"] as IdeExtensionConfig | undefined
+			const documentSelectors: vscode.DocumentSelector = [
+				{ language: "javascript", pattern: `!${CONFIGURATION.FILES.PROJECT}` },
+				...(ideExtension?.documentSelectors ?? []),
+			]
+
+			return {
+				activate: () => {
+					resources.push(
+						deactivateBeforeClose(
+							vscode.languages.registerCodeActionsProvider(
+								documentSelectors,
+								new ExtractMessage(),
+								{ providedCodeActionKinds: ExtractMessage.providedCodeActionKinds }
+							)
+						)
+					)
+					messagePreview({ subscriptions: resources, session })
+					void linterDiagnostics({ subscriptions: resources, fs: args.fileSystem, session }).catch(
+						handleError
+					)
+					if (args.messageView) {
+						resources.push(deactivateBeforeClose(args.messageView.bindProject(session)))
+					}
+				},
+			}
+		},
 		publishActiveSession: (session) =>
 			setActiveProject(session ? { project: session.project, path: session.path } : undefined),
 	})

--- a/test/specs/project-session-lifecycle.e2e.test.ts
+++ b/test/specs/project-session-lifecycle.e2e.test.ts
@@ -66,5 +66,29 @@ describe("Project session lifecycle", () => {
 			},
 			{ timeout: 60_000, interval: 500 }
 		)
+
+		const result = await browser.executeWorkbench(async (vscodeApi: typeof vscode) => {
+			const extension = vscodeApi.extensions.getExtension("inlang.vs-code-extension")
+			await extension?.activate()
+			const workspaceFolder = vscodeApi.workspace.workspaceFolders?.[0]
+			if (!workspaceFolder) throw new Error("Expected the E2E workspace to be open")
+			const document = await vscodeApi.workspace.openTextDocument(
+				vscodeApi.Uri.joinPath(workspaceFolder.uri, "src/app.js")
+			)
+			const countSherlockCodeActions = async () => {
+				const actions = await vscodeApi.commands.executeCommand<vscode.CodeAction[]>(
+					"vscode.executeCodeActionProvider",
+					document.uri,
+					new vscodeApi.Range(0, 0, 0, 1)
+				)
+				return actions?.filter((action) => action.title === "Sherlock: Extract Message").length ?? 0
+			}
+			const beforeReload = await countSherlockCodeActions()
+			const reload = await vscodeApi.commands.executeCommand<string>("sherlock.reloadProject")
+			const afterReload = await countSherlockCodeActions()
+			return { beforeReload, reload, afterReload }
+		})
+
+		expect(result).toEqual({ beforeReload: 1, reload: "committed", afterReload: 1 })
 	})
 })


### PR DESCRIPTION
## What changed

This PR moves project-specific setup out of `activate()` and into a dedicated project session environment.

The new environment now takes care of:

- loading and preparing a project
- setting up code actions, previews, diagnostics, and the message view
- starting the plugin resource watcher
- updating the active project and notifying the UI
- cleaning everything up when the project changes or the extension shuts down

`main.ts` now creates the environment and installs the returned runtime instead of assembling the whole project lifecycle itself.

I also added tests for failed loads, failed setup, failed active-project updates, overlapping project switches, watcher reconciliation, cleanup order, and repeated shutdown. The extension-host test now checks that reloading a project does not register the Sherlock extract-message action twice.

## Why

Project setup was spread between extension activation, the runtime, and the session lifecycle. That made it hard to see which resources belonged to a project and in what order they should be started or stopped.

Keeping this work in one place makes the lifecycle easier to follow and gives us one useful boundary to test.

This is an internal refactor. It should not change how Sherlock behaves for users.

## Replacement behavior

The existing safety rules stay the same:

- the current project stays active while the next one loads
- if loading or setup fails, the current project remains active
- if projects are selected quickly, only the newest request can become active
- resources from the old project are stopped before its project is closed
- the new resource watcher starts after the old project is gone
- each successful replacement sends one project-change event
- shutdown remains bounded and safe to call more than once

## Validation

- [x] `pnpm exec vitest run` — 292 tests passed
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm run build`
- [x] Prettier check on all changed files
- [x] `git diff --check`
- [x] Project session lifecycle E2E
- [x] i18next resource-watching E2E
- [x] JSON resource-watching E2E — passed twice on its own and once together with the i18next spec

The VS Code WebDriver runner did lose its DevTools connection during a separate three-spec run. The affected resource specs passed when rerun, and the same runner problem was reproduced on the base commit. No product-code workaround was added for it.

## Review guide

The easiest review order is:

1. `src/utilities/project/projectSessionEnvironment.ts` — the new home for project setup and cleanup
2. `src/main.ts` — the smaller activation path
3. `src/utilities/project/projectRuntime.ts` — the runtime interface that commands still use
4. `src/utilities/project/projectSessionEnvironment.test.ts` — replacement, rollback, watcher, and shutdown coverage
5. `test/specs/project-session-lifecycle.e2e.test.ts` — duplicate-registration coverage

The most important things to check are that a project is not published before setup succeeds, a failed replacement leaves the old project active, and the old watcher is gone before the new one takes over.

## Risk and rollback

The main risk is changing the order in which project resources start and stop. The new tests cover failures, races, cleanup order, watcher handoff, and repeated shutdown.

There are no dependency, lockfile, workspace, settings schema, or project format changes. The five commits can be reverted together without a migration.

## Out of scope

- changing how project data is saved
- changing resource watcher matching or debounce behavior
- removing the runtime registry used by commands
- redesigning extension views or other user-facing behavior

Follow-up to #213 and #214.
