### PR TITLE
Add minor release changeset for project synchronization

### DIFF
--- a/.changeset/tame-rivers-notice.md
+++ b/.changeset/tame-rivers-notice.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": minor
+---
+
+Improve project-session lifecycle handling and keep project resource loading, saving, and file watching synchronized.


### PR DESCRIPTION
Adds a minor changeset for `vs-code-extension` covering the merged project-session lifecycle and project-resource synchronization work from #215 and #216.

This schedules the next release as 2.4.0.

Validation: `pnpm exec changeset status` reports a minor bump for `vs-code-extension`.