### PR TITLE
fix: preserve externally added translation keys

### DIFF
--- a/.changeset/calm-pandas-protect.md
+++ b/.changeset/calm-pandas-protect.md
@@ -1,0 +1,5 @@
+---
+"vs-code-extension": patch
+---
+
+Prevent stale Sherlock saves from overwriting translation keys added by external tools before resource reconciliation completes.

--- a/src/utilities/project/projectResourceSynchronization.test.ts
+++ b/src/utilities/project/projectResourceSynchronization.test.ts
@@ -213,6 +213,78 @@ describe("project resource synchronization", () => {
 		await session.ownedResources[0]?.dispose()
 	})
 
+	it("does not overwrite an external resource edit before its watcher event is handled", async () => {
+		vi.useFakeTimers()
+		const projectPath = path.join(path.sep, "workspace", "project.inlang")
+		const resourcePath = path.join(path.sep, "workspace", "translations", "en.json")
+		const project = {
+			settings: { get: vi.fn(async () => ({ baseLocale: "en", locales: ["en"] })) },
+			plugins: {
+				get: vi.fn(async () => [
+					{
+						key: "plugin.example",
+						importFiles: vi.fn(),
+						toBeImportedFiles: vi.fn(async () => [{ path: resourcePath, locale: "en" }]),
+					},
+				]),
+			},
+		}
+		host.contents.set(resourcePath, new TextEncoder().encode('{"existing":"initial"}'))
+		const session = createSession(project, projectPath)
+		const synchronization = createProjectResourceSynchronization()
+		await synchronization.watch(session as any)
+
+		host.contents.set(
+			resourcePath,
+			new TextEncoder().encode('{"existing":"initial","addedExternally":"preserve me"}')
+		)
+
+		await expect(synchronization.save(project as any, projectPath)).rejects.toThrow(
+			"Project resources changed outside Sherlock"
+		)
+		expect(host.saveProjectToDirectory).not.toHaveBeenCalled()
+		expect(new TextDecoder().decode(host.contents.get(resourcePath))).toContain(
+			'"addedExternally":"preserve me"'
+		)
+		await vi.advanceTimersByTimeAsync(150)
+		expect(session.requestReconciliation).toHaveBeenCalledOnce()
+		await session.ownedResources[0]?.dispose()
+	})
+
+	it("does not save a stale project while external reconciliation is pending", async () => {
+		vi.useFakeTimers()
+		const projectPath = path.join(path.sep, "workspace", "project.inlang")
+		const resourcePath = path.join(path.sep, "workspace", "translations", "en.json")
+		const project = {
+			settings: { get: vi.fn(async () => ({ baseLocale: "en", locales: ["en"] })) },
+			plugins: {
+				get: vi.fn(async () => [
+					{
+						key: "plugin.example",
+						importFiles: vi.fn(),
+						toBeImportedFiles: vi.fn(async () => [{ path: resourcePath, locale: "en" }]),
+					},
+				]),
+			},
+		}
+		host.contents.set(resourcePath, new TextEncoder().encode("initial"))
+		const session = createSession(project, projectPath)
+		const synchronization = createProjectResourceSynchronization()
+		await synchronization.watch(session as any)
+
+		host.contents.set(resourcePath, new TextEncoder().encode("edited externally"))
+		host.watchers[0]?.callbacks.change?.({ fsPath: resourcePath })
+		await vi.waitFor(() => expect(host.readFile).toHaveBeenCalledTimes(2))
+
+		await expect(synchronization.save(project as any, projectPath)).rejects.toThrow(
+			"Project resources changed outside Sherlock"
+		)
+		expect(host.saveProjectToDirectory).not.toHaveBeenCalled()
+		await vi.advanceTimersByTimeAsync(150)
+		expect(session.requestReconciliation).toHaveBeenCalledOnce()
+		await session.ownedResources[0]?.dispose()
+	})
+
 	it("reconciles an external resource edit that overlaps a Sherlock save", async () => {
 		vi.useFakeTimers()
 		const projectPath = path.join(path.sep, "workspace", "project.inlang")
@@ -665,14 +737,16 @@ describe("project resource synchronization", () => {
 		const synchronization = createProjectResourceSynchronization()
 		await synchronization.watch(session as any)
 		const refreshRead = deferred<Uint8Array>()
-		host.readFile.mockReturnValueOnce(refreshRead.promise)
+		host.readFile
+			.mockResolvedValueOnce(new TextEncoder().encode("initial"))
+			.mockReturnValueOnce(refreshRead.promise)
 		host.saveProjectToDirectory.mockImplementationOnce(async ({ fs }) => {
 			await fs.writeFile("../translations/en.json", "saved by Sherlock")
 			host.watchers[0]?.callbacks.change?.({ fsPath: resourcePath })
 		})
 
 		const save = synchronization.save(project as any, projectPath)
-		await vi.waitFor(() => expect(host.readFile).toHaveBeenCalledTimes(2))
+		await vi.waitFor(() => expect(host.readFile).toHaveBeenCalledTimes(3))
 		refreshRead.resolve(new TextEncoder().encode("saved by Sherlock"))
 		host.contents.set(resourcePath, new TextEncoder().encode("edited externally"))
 		await save

--- a/src/utilities/project/projectResourceSynchronization.ts
+++ b/src/utilities/project/projectResourceSynchronization.ts
@@ -22,6 +22,7 @@ type ResourceWriteState = {
 	activeWrites: number
 	revision: number
 	refreshers: Set<() => Promise<void>>
+	preflightChecks: Set<() => Promise<void>>
 	trackedPaths: Map<string, number>
 	expectedFingerprints: Map<string, string | typeof MISSING_RESOURCE>
 	writeQueue: Promise<void>
@@ -171,6 +172,7 @@ function resourceWriteState(project: object, resourceWrites: WeakMap<object, Res
 			activeWrites: 0,
 			revision: 0,
 			refreshers: new Set(),
+			preflightChecks: new Set(),
 			trackedPaths: new Map(),
 			expectedFingerprints: new Map(),
 			writeQueue: Promise.resolve(),
@@ -187,6 +189,7 @@ async function runWithResourceWrite<T>(
 ) {
 	const state = writeState(project)
 	const queuedWrite = state.writeQueue.then(async () => {
+		for (const preflightCheck of state.preflightChecks) await preflightCheck()
 		state.revision += 1
 		state.expectedFingerprints.clear()
 		state.release = new Promise<void>((resolve) => {
@@ -258,6 +261,7 @@ async function watchProjectResources(args: {
 	let initializingFingerprints = true
 	let changedDuringInitialization = false
 	let changedAcrossLoadHandoff = false
+	let reconciliationPending = false
 	let debounceTimer: NodeJS.Timeout | undefined
 
 	const requestReconciliation = () => {
@@ -268,6 +272,7 @@ async function watchProjectResources(args: {
 
 	const scheduleReload = () => {
 		if (!acceptingEvents) return
+		reconciliationPending = true
 		if (debounceTimer) clearTimeout(debounceTimer)
 		debounceTimer = setTimeout(requestReconciliation, DEBOUNCE_MS)
 	}
@@ -341,6 +346,26 @@ async function watchProjectResources(args: {
 	}
 
 	const writeState = args.writeState(args.session.project)
+	const checkResourcesBeforeWrite = async () => {
+		if (!acceptingEvents) return
+		if (!reconciliationPending) {
+			for (const filePath of resourcePaths) {
+				let currentFingerprint: string | typeof MISSING_RESOURCE
+				try {
+					currentFingerprint = await fingerprint(filePath)
+				} catch (error) {
+					if (!isMissingFile(error)) throw error
+					currentFingerprint = MISSING_RESOURCE
+				}
+				if (fingerprints.get(filePath) === currentFingerprint) continue
+				fingerprints.set(filePath, currentFingerprint)
+				scheduleReload()
+			}
+		}
+		if (reconciliationPending) {
+			throw new ProjectResourcesChangedError()
+		}
+	}
 	const refreshAfterWrite = async () => {
 		for (const [filePath, expectedFingerprint] of writeState.expectedFingerprints) {
 			if (!fingerprints.has(filePath)) continue
@@ -365,6 +390,7 @@ async function watchProjectResources(args: {
 			}
 		}
 	}
+	writeState.preflightChecks.add(checkResourcesBeforeWrite)
 	for (const filePath of resourcePaths) {
 		writeState.trackedPaths.set(filePath, (writeState.trackedPaths.get(filePath) ?? 0) + 1)
 	}
@@ -374,6 +400,7 @@ async function watchProjectResources(args: {
 		dispose: async () => {
 			acceptingEvents = false
 			writeState.refreshers.delete(refreshAfterWrite)
+			writeState.preflightChecks.delete(checkResourcesBeforeWrite)
 			for (const filePath of resourcePaths) {
 				const owners = writeState.trackedPaths.get(filePath) ?? 0
 				if (owners <= 1) writeState.trackedPaths.delete(filePath)
@@ -464,6 +491,13 @@ async function watchProjectResources(args: {
 	if (changedDuringInitialization || changedAcrossLoadHandoff) scheduleReload()
 
 	return descriptors
+}
+
+export class ProjectResourcesChangedError extends Error {
+	constructor() {
+		super("Project resources changed outside Sherlock; reload before saving.")
+		this.name = "ProjectResourcesChangedError"
+	}
 }
 
 function observeFileSystemMutations(


### PR DESCRIPTION
Fixes #219

## Summary
- verify watched resource fingerprints immediately before every Sherlock export
- abort stale saves and request reconciliation when an external edit is detected or already pending
- cover edits that race both before watcher delivery and during pending reconciliation
- add a patch changeset

## Validation
- `pnpm test` (275 passed, 2 skipped, 2 todo)
- `pnpm run build`
- `git diff --check`